### PR TITLE
[FEAT]#38 명함 상세 페이지 마크업

### DIFF
--- a/src/app/card/[...id]/page.tsx
+++ b/src/app/card/[...id]/page.tsx
@@ -1,0 +1,64 @@
+import PathAnalysisGrid from '@/components/card-detail/path-analysis-grid';
+import StatCardGrid from '@/components/card-detail/stat-card-grid';
+import WeeklyChart from '@/components/card-detail/weekly-chart';
+import FlipCard from '@/components/card/flip-card';
+
+const page = () => {
+  return (
+    <>
+      <div className='flex items-center border-b border-solid border-b-zinc-100 p-6'>
+        <div className='mx-auto flex w-full max-w-5xl items-center justify-start'>
+          <button className='mr-2'>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              className='h-5 w-5'
+              fill='none'
+              viewBox='0 0 24 24'
+              stroke='currentColor'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                strokeWidth={2}
+                d='M15 19l-7-7 7-7'
+              />
+            </svg>
+          </button>
+          <h1 className='text-lg font-medium'>내 명함 상세</h1>
+        </div>
+      </div>
+      <div className='mx-auto max-w-5xl'>
+        <div className='grid grid-cols-3'>
+          <div className='col-span-1 flex flex-col border-r border-[#F4F4F5] p-[14px] text-[18px] shadow-[0px_3px_18px_0px_rgba(0,0,0,0.04)]'>
+            <select name='' id='' className='py-2'>
+              <option value='test1'>test1</option>
+              <option value='test2'>test2</option>
+              <option value='test3'>test3</option>
+            </select>
+            <FlipCard />
+          </div>
+          <div className='col-span-2 bg-[#F5F6FA]'>
+            <div className='flex items-center justify-between bg-white p-4 shadow-[0px_4px_20px_0px_rgba(0,0,0,0.04)]'>
+              <h2 className='text-lg font-bold'>내 명함 통계</h2>
+              <div className='flex gap-2'>
+                <button className='px-2 py-1 text-[14px] text-[#3970D5]'>
+                  CSV
+                </button>
+                <button className='px-2 py-1 text-[14px] text-[#3970D5]'>
+                  PDF
+                </button>
+              </div>
+            </div>
+            <div className='p-5'>
+              <StatCardGrid />
+              <WeeklyChart />
+              <PathAnalysisGrid />
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default page;

--- a/src/app/card/[...id]/page.tsx
+++ b/src/app/card/[...id]/page.tsx
@@ -7,6 +7,7 @@ const page = () => {
   return (
     <>
       <div className='flex items-center border-b border-solid border-b-zinc-100 p-6'>
+        {/* 페이지 타이틀 */}
         <div className='mx-auto flex w-full max-w-5xl items-center justify-start'>
           <button className='mr-2'>
             <svg
@@ -29,15 +30,19 @@ const page = () => {
       </div>
       <div className='mx-auto max-w-5xl'>
         <div className='grid grid-cols-3'>
+          {/* 왼쪽 컬럼 */}
           <div className='col-span-1 flex flex-col border-r border-[#F4F4F5] p-[14px] text-[18px] shadow-[0px_3px_18px_0px_rgba(0,0,0,0.04)]'>
             <select name='' id='' className='py-2'>
               <option value='test1'>test1</option>
               <option value='test2'>test2</option>
               <option value='test3'>test3</option>
             </select>
+            {/* 명함 플립 */}
             <FlipCard />
           </div>
+          {/* 오른쪽 컬럼 - 통계 정보 */}
           <div className='col-span-2 bg-[#F5F6FA]'>
+            {/* 통계 헤더 */}
             <div className='flex items-center justify-between bg-white p-4 shadow-[0px_4px_20px_0px_rgba(0,0,0,0.04)]'>
               <h2 className='text-lg font-bold'>내 명함 통계</h2>
               <div className='flex gap-2'>
@@ -50,8 +55,13 @@ const page = () => {
               </div>
             </div>
             <div className='p-5'>
+              {/* 통계 카드 그리드 */}
               <StatCardGrid />
+
+              {/* 주간 통계 차트 */}
               <WeeklyChart />
+
+              {/* 경로 분석 차트 그리드 */}
               <PathAnalysisGrid />
             </div>
           </div>

--- a/src/components/card-detail/path-analysis-chart.tsx
+++ b/src/components/card-detail/path-analysis-chart.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  title: string;
+}
+const PathAnalysisChart = ({ title }: Props) => (
+  <div className='rounded-lg bg-white p-4'>
+    <h3 className='mb-4 text-base font-medium text-[#1A1A1A]'>{title}</h3>
+    <div className='flex h-36 items-center justify-center rounded-lg bg-gray-100'>
+      <span className='text-gray-400'>차트 영역</span>
+    </div>
+  </div>
+);
+export default PathAnalysisChart;

--- a/src/components/card-detail/path-analysis-grid.tsx
+++ b/src/components/card-detail/path-analysis-grid.tsx
@@ -1,0 +1,14 @@
+import PathAnalysisChart from './path-analysis-chart';
+
+const PathAnalysisGrid = () => (
+  <div className='grid grid-cols-1 gap-4 md:grid-cols-3'>
+    <div className='col-span-2'>
+      <PathAnalysisChart title='명함 유입 경로' />
+    </div>
+    <div className='col-span-1'>
+      <PathAnalysisChart title='유저 저장 경로' />
+    </div>
+  </div>
+);
+
+export default PathAnalysisGrid;

--- a/src/components/card-detail/path-analysis-grid.tsx
+++ b/src/components/card-detail/path-analysis-grid.tsx
@@ -6,7 +6,7 @@ const PathAnalysisGrid = () => (
       <PathAnalysisChart title='명함 유입 경로' />
     </div>
     <div className='col-span-1'>
-      <PathAnalysisChart title='유저 저장 경로' />
+      <PathAnalysisChart title='유저 인터렉션 횟수' />
     </div>
   </div>
 );

--- a/src/components/card-detail/stat-card-grid.tsx
+++ b/src/components/card-detail/stat-card-grid.tsx
@@ -2,8 +2,8 @@ import StatCard from './stat-card';
 
 const StatCardGrid = () => (
   <div className='mb-6 grid grid-cols-1 gap-4 md:grid-cols-3'>
-    <StatCard title='월간 조회수' />
-    <StatCard title='월간 저장수' />
+    <StatCard title='월간 조회 수' />
+    <StatCard title='월간 저장 수' />
     <StatCard title='월 평균 체류 시간' />
   </div>
 );

--- a/src/components/card-detail/stat-card-grid.tsx
+++ b/src/components/card-detail/stat-card-grid.tsx
@@ -1,0 +1,11 @@
+import StatCard from './stat-card';
+
+const StatCardGrid = () => (
+  <div className='mb-6 grid grid-cols-1 gap-4 md:grid-cols-3'>
+    <StatCard title='월간 조회수' />
+    <StatCard title='월간 저장수' />
+    <StatCard title='월 평균 체류 시간' />
+  </div>
+);
+
+export default StatCardGrid;

--- a/src/components/card-detail/stat-card.tsx
+++ b/src/components/card-detail/stat-card.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface Props {
+  title: string;
+  value?: string | number;
+}
+
+const StatCard = ({ title, value = '-' }: Props) => (
+  <div className='rounded-lg bg-white p-4'>
+    <p className='text-[14px] text-gray-500'>{title}</p>
+    <p className='mt-1 text-[18px] font-bold'>{value}</p>
+    <p className='text-medium text-[12px]'>-</p>
+  </div>
+);
+
+export default StatCard;

--- a/src/components/card-detail/weekly-chart.tsx
+++ b/src/components/card-detail/weekly-chart.tsx
@@ -1,0 +1,25 @@
+const WeeklyChart = () => (
+  <div className='mb-6 rounded-xl bg-white p-4'>
+    <div className='mb-4 flex items-center justify-between'>
+      <p className='text-base font-medium'>
+        포트폴리오 주간 통계 -{' '}
+        <span className='text-[#70737C]'>01.13 ~ 01.19</span>
+      </p>
+    </div>
+    <div className='grid grid-cols-3'>
+      <div className='col-span-2 mb-2 flex h-40 items-center justify-center rounded-lg bg-gray-100'>
+        <span className='text-gray-400'>차트 영역</span>
+      </div>
+      <div className='col-span-1 mb-6 flex flex-col items-start justify-center text-xs text-gray-500'>
+        <div className='mx-auto my-0 text-base font-medium text-[#1A1A1A]'>
+          <p className='text-[12px] text-[#3970D5]'>주간 조회 수</p>
+          <p>0회</p>
+          <p className='text-[12px] text-[#E66B00]'>주간 저장 수</p>
+          <p>0회</p>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default WeeklyChart;

--- a/src/components/card/flip-card.tsx
+++ b/src/components/card/flip-card.tsx
@@ -1,0 +1,57 @@
+'use client';
+import clsx from 'clsx';
+import { useState } from 'react';
+
+const FlipCard = () => {
+  const [isFlipped, setIsFlipped] = useState(false);
+  const CARD_DEFAULT_STYLE =
+    'bg-slate-700 absolute flex justify-center items-center backface-hidden w-[240px] h-[150px] shadow-xl rounded-lg';
+  const CARD_DEFAULT_WRAPPER_STYLE =
+    'relative transition-transform duration-1000 cursor-pointer transform-style-preserve-3d';
+
+  return (
+    <div className='relative flex flex-1 flex-col items-center justify-between'>
+      <div className='flex flex-col items-center justify-center'>
+        <div className='relative mb-4 flex items-center justify-center'>
+          <div className='m-5 h-[150px] w-[240px] perspective-1000'>
+            <div
+              className={clsx(
+                CARD_DEFAULT_WRAPPER_STYLE,
+                isFlipped && 'rotate-y-180'
+              )}
+            >
+              <div className={CARD_DEFAULT_STYLE}>front</div>
+              <div className={clsx(CARD_DEFAULT_STYLE, 'rotate-y-180')}>
+                back
+              </div>
+            </div>
+          </div>
+          <button
+            className='absolute bottom-0 z-10 flex h-[34px] w-[34px] items-center justify-center rounded-full bg-[#DADADA33] text-[18px] text-[#1a1a1a] shadow-md'
+            onClick={() => setIsFlipped((pre: boolean) => !pre)}
+          >
+            -
+          </button>
+        </div>
+        <button className='mb-2 flex w-full justify-center rounded-full bg-[#3970D5] px-3 py-[10px] text-[14px] text-white'>
+          편집하기
+        </button>
+        <button className='flex w-full justify-center rounded-full bg-[#F4F4F5] px-3 py-[10px] text-[14px]'>
+          저장 및 공유하기
+        </button>
+        <div className='my-5 mb-3 h-[1px] w-full bg-[#F5F6FA]' />
+        <span className='cursor-pointer text-[14px] text-[#878A93]'>
+          공유 화면 미리보기
+        </span>
+      </div>
+      <div className='flex w-full flex-col items-center justify-center'>
+        <div className='my-5 mb-3 h-[1px] w-full bg-[#F5F6FA]' />
+        <span className='cursor-pointer text-[14px] text-[#878A93]'>
+          삭제하기
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default FlipCard;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,6 @@
 import type { Config } from 'tailwindcss';
+import tailwindcssAnimate from 'tailwindcss-animate';
+import { CSSRuleObject } from 'tailwindcss/types/config';
 
 const config: Config = {
   darkMode: ['class'],
@@ -94,6 +96,34 @@ const config: Config = {
     },
   },
 
-  plugins: [require('tailwindcss-animate')],
+  plugins: [
+    tailwindcssAnimate,
+    function ({
+      addUtilities,
+    }: {
+      addUtilities: (
+        _utilities: CSSRuleObject | CSSRuleObject[],
+        _options?: Partial<{
+          respectPrefix: boolean;
+          respectImportant: boolean;
+        }>
+      ) => void;
+    }) {
+      addUtilities({
+        '.perspective-1000': {
+          perspective: '1000px',
+        },
+        '.transform-style-preserve-3d': {
+          'transform-style': 'preserve-3d',
+        },
+        '.backface-hidden': {
+          'backface-visibility': 'hidden',
+        },
+        '.rotate-y-180': {
+          transform: 'rotateY(180deg)',
+        },
+      });
+    },
+  ],
 };
 export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,12 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "src/app/page.tsx"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #38

<br>

## 📝 작업 내용

- 내 명함 상세 마크업
- 카드 플립 애니메이션 적용

<br>

## 🖼 스크린샷


https://github.com/user-attachments/assets/5f9acba8-b536-4626-8568-545d01287dbf


<br>

## 💬 리뷰 요구사항

> 없습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- **카드 상세 보기 페이지 도입:** 카드의 상세 정보와 통계 데이터를 한눈에 확인할 수 있는 새로운 레이아웃이 추가되었습니다.
	- **인터랙티브 카드 기능:** 카드 전환 버튼을 통해 카드를 뒤집으며 편집, 저장, 공유 등의 기능을 지원합니다.
	- **데이터 시각화 컴포넌트:** 주간 통계, 경로 분석, 통계 카드 등 다양한 차트와 그리드를 통해 정보를 직관적으로 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->