### PR TITLE
[FEAT]#74 명함 인터렉션 히트맵

### DIFF
--- a/src/apis/card-interaction.ts
+++ b/src/apis/card-interaction.ts
@@ -1,6 +1,12 @@
 import { DB_COLUMNS, TABLES } from '@/constants/tables.constant';
 import { createClient } from '@/utils/supabase/client';
 
+/**
+ * 슬러그를 기반으로 명함 ID를 조회
+ *
+ * @param slug 명함 슬러그
+ * @returns 해당 슬러그에 매칭 명함 ID
+ */
 export const getCardId = async (slug: string) => {
   const supabase = await createClient();
   const { data, error } = await supabase

--- a/src/apis/card-interaction.ts
+++ b/src/apis/card-interaction.ts
@@ -18,5 +18,9 @@ export const getCardId = async (slug: string) => {
     throw error;
   }
 
+  if (!data || data.length === 0) {
+    throw new Error(`명함을 찾을 수 없습니다: ${slug}`);
+  }
+
   return data[0].id;
 };

--- a/src/apis/card-interaction.ts
+++ b/src/apis/card-interaction.ts
@@ -1,0 +1,16 @@
+import { DB_COLUMNS, TABLES } from '@/constants/tables.constant';
+import { createClient } from '@/utils/supabase/client';
+
+export const getCardId = async (slug: string) => {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from(TABLES.CARDS)
+    .select(DB_COLUMNS.CARDS.ID)
+    .eq(DB_COLUMNS.CARDS.SLUG, slug);
+
+  if (error) {
+    throw error;
+  }
+
+  return data[0].id;
+};

--- a/src/apis/card-social-list.ts
+++ b/src/apis/card-social-list.ts
@@ -10,7 +10,5 @@ export const getCardSocialLists = async (card_id: string) => {
 
   if (error) throw error;
 
-  console.log(data);
-
   return data;
 };

--- a/src/apis/card-social-list.ts
+++ b/src/apis/card-social-list.ts
@@ -1,6 +1,12 @@
 import { DB_COLUMNS, TABLES } from '@/constants/tables.constant';
 import { createClient } from '@/utils/supabase/client';
 
+/**
+ * 명함 ID에 해당하는 소셜 링크 목록 조회
+ *
+ * @param card_id 조회할 명함 ID
+ * @returns 명함에 연결된 소셜 링크 배열
+ */
 export const getCardSocialLists = async (card_id: string) => {
   const supabase = await createClient();
   const { data, error } = await supabase

--- a/src/apis/card-social-list.ts
+++ b/src/apis/card-social-list.ts
@@ -1,0 +1,16 @@
+import { DB_COLUMNS, TABLES } from '@/constants/tables.constant';
+import { createClient } from '@/utils/supabase/client';
+
+export const getCardSocialLists = async (card_id: string) => {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from(TABLES.LINKS)
+    .select('*')
+    .eq(DB_COLUMNS.LINKS.CARD_ID, card_id);
+
+  if (error) throw error;
+
+  console.log(data);
+
+  return data;
+};

--- a/src/apis/interaction.ts
+++ b/src/apis/interaction.ts
@@ -1,0 +1,84 @@
+import { DB_COLUMNS, STORAGE, TABLES } from '@/constants/tables.constant';
+import { formatToDateString } from '@/utils/interaction/format-date';
+import { createClient } from '@/utils/supabase/client';
+
+interface LogInteractionParams {
+  cardId: string;
+  elementName: string | null;
+  type: 'click' | 'save' | null | undefined;
+  startedAt: string;
+  viewerIp: string;
+  sessionId: string;
+  source: 'direct' | 'qr' | 'link' | 'iframe' | null;
+}
+
+export const getIpAddress = async (): Promise<string> => {
+  const res = await fetch('https://api.ipify.org?format=json');
+  const data = await res.json();
+  return data.ip;
+};
+
+export const logInteraction = async ({
+  cardId,
+  elementName,
+  type,
+  startedAt,
+  viewerIp,
+  sessionId,
+  source,
+}: LogInteractionParams) => {
+  const now = formatToDateString(new Date());
+
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.from(TABLES.CARD_VIEWS).insert({
+    card_id: cardId,
+    element_name: elementName,
+    occurred_at: now,
+    started_at: startedAt,
+    end_at: now,
+    source: source,
+    type: type,
+    viewer_id: null,
+    viewer_ip: viewerIp,
+    session_id: sessionId,
+  });
+
+  if (error) throw error;
+  return data;
+};
+
+export const endSession = async (sessionId: string, reason: string) => {
+  const now = formatToDateString(new Date());
+  const supabase = await createClient();
+
+  if (reason === 'page-exit') {
+    navigator.sendBeacon(
+      '/api/log-exit',
+      JSON.stringify({
+        session_id: sessionId,
+        end_at: now,
+      })
+    );
+    return { success: true };
+  } else {
+    const { error } = await supabase
+      .from(TABLES.CARD_VIEWS)
+      .update({ end_at: now })
+      .eq(DB_COLUMNS.CARD_VIEWS.SESSION_ID, sessionId);
+
+    if (error) throw error;
+    return { success: true };
+  }
+};
+
+export const downloadCardImage = async () => {
+  const supabase = await createClient();
+  const { data, error } = await supabase.storage
+    .from(STORAGE.CARDS)
+    .download('card_test.jpg');
+
+  if (error) throw error;
+
+  return data;
+};

--- a/src/apis/interaction.ts
+++ b/src/apis/interaction.ts
@@ -12,12 +12,18 @@ interface LogInteractionParams {
   source: 'direct' | 'qr' | 'link' | 'iframe' | null;
 }
 
+/**
+ * 사용자 IP 주소 조회
+ */
 export const getIpAddress = async (): Promise<string> => {
   const res = await fetch('https://api.ipify.org?format=json');
   const data = await res.json();
   return data.ip;
 };
 
+/**
+ * 사용자 인터랙션 로깅
+ */
 export const logInteraction = async ({
   cardId,
   elementName,
@@ -48,6 +54,9 @@ export const logInteraction = async ({
   return data;
 };
 
+/**
+ * 세션 종료 처리
+ */
 export const endSession = async (sessionId: string, reason: string) => {
   const now = formatToDateString(new Date());
   const supabase = await createClient();
@@ -72,7 +81,11 @@ export const endSession = async (sessionId: string, reason: string) => {
   }
 };
 
+/**
+ * 명함 이미지 다운로드
+ */
 export const downloadCardImage = async () => {
+  // dummy data 사용 (추후 변경 예정)
   const supabase = await createClient();
   const { data, error } = await supabase.storage
     .from(STORAGE.CARDS)

--- a/src/apis/interaction.ts
+++ b/src/apis/interaction.ts
@@ -16,9 +16,17 @@ interface LogInteractionParams {
  * 사용자 IP 주소 조회
  */
 export const getIpAddress = async (): Promise<string> => {
-  const res = await fetch('https://api.ipify.org?format=json');
-  const data = await res.json();
-  return data.ip;
+  try {
+    const res = await fetch('https://api.ipify.org?format=json');
+    if (!res.ok) {
+      throw new Error(`IP 주소 조회 실패: ${res.status} ${res.statusText}`);
+    }
+    const data = await res.json();
+    return data.ip;
+  } catch (error) {
+    console.error('IP 주소 조회 중 오류 발생:', error);
+    throw new Error('IP 주소를 가져오는 데 실패했습니다.');
+  }
 };
 
 /**

--- a/src/apis/interaction.ts
+++ b/src/apis/interaction.ts
@@ -92,12 +92,11 @@ export const endSession = async (sessionId: string, reason: string) => {
 /**
  * 명함 이미지 다운로드
  */
-export const downloadCardImage = async () => {
-  // dummy data 사용 (추후 변경 예정)
+export const downloadCardImage = async (cardId: string, fileName: string) => {
   const supabase = await createClient();
   const { data, error } = await supabase.storage
     .from(STORAGE.CARDS)
-    .download('card_test.jpg');
+    .download(`${cardId}/${fileName}`);
 
   if (error) throw error;
 

--- a/src/apis/interaction.ts
+++ b/src/apis/interaction.ts
@@ -9,7 +9,7 @@ interface LogInteractionParams {
   startedAt: string;
   viewerIp: string;
   sessionId: string;
-  source: 'direct' | 'qr' | 'link' | 'iframe' | null;
+  source: 'direct' | 'qr' | 'link' | 'tag' | null;
 }
 
 /**

--- a/src/app/api/log-exit/route.ts
+++ b/src/app/api/log-exit/route.ts
@@ -2,8 +2,15 @@ import { DB_COLUMNS, TABLES } from '@/constants/tables.constant';
 import { createClient } from '@/utils/supabase/client';
 import { NextResponse } from 'next/server';
 
+/**
+ * 세션 종료 시 명함 조회 정보를 업데이트
+ *
+ * @param request
+ * @returns 성공 시 {success: true}, 실패 시 에러 메시지와 적절한 상태 코드
+ */
 export async function POST(request: Request) {
   try {
+    // 요청 본문에서 세션 ID와 종료 시간 추출
     const { session_id, end_at } = await request.json();
     const supabase = await createClient();
 
@@ -14,7 +21,6 @@ export async function POST(request: Request) {
       );
     }
 
-    // 슈파베이스에 데이터 저장
     const { error } = await supabase
       .from(TABLES.CARD_VIEWS)
       .update({ end_at })

--- a/src/app/api/log-exit/route.ts
+++ b/src/app/api/log-exit/route.ts
@@ -1,0 +1,33 @@
+import { DB_COLUMNS, TABLES } from '@/constants/tables.constant';
+import { createClient } from '@/utils/supabase/client';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const { session_id, end_at } = await request.json();
+    const supabase = await createClient();
+
+    if (!session_id || !end_at) {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      );
+    }
+
+    // 슈파베이스에 데이터 저장
+    const { error } = await supabase
+      .from(TABLES.CARD_VIEWS)
+      .update({ end_at })
+      .eq(DB_COLUMNS.CARD_VIEWS.SESSION_ID, session_id);
+
+    if (error) {
+      console.error('Supabase error:', error);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error details:', error);
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/src/components/card/flip-card.tsx
+++ b/src/components/card/flip-card.tsx
@@ -1,7 +1,9 @@
 'use client';
 import clsx from 'clsx';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import FlipArrow from '@/components/icons/flip-arrow';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useInteractionTracker } from '@/hooks/use-interaction-tracker';
 
 interface FlipCardParam {
   attached?: boolean;
@@ -9,12 +11,39 @@ interface FlipCardParam {
 
 const FlipCard = ({ attached }: FlipCardParam) => {
   const [isFlipped, setIsFlipped] = useState(false);
+  const [startedAt, setStartedAt] = useState<Date | null>(null);
   const CARD_DEFAULT_STYLE =
     'bg-slate-700 absolute flex justify-center items-center backface-hidden w-full shadow-[37px_108px_32px_0px_rgba(0,0,0,0.00),24px_69px_29px_0px_rgba(0,0,0,0.01),13px_39px_25px_0px_rgba(0,0,0,0.05),6px_17px_18px_0px_rgba(0,0,0,0.09),1px_4px_10px_0px_rgba(0,0,0,0.10)] aspect-[9/5]';
   const CARD_DEFAULT_WRAPPER_STYLE =
     'relative transition-transform duration-1000 cursor-pointer transform-style-preserve-3d';
   const CARD_DEFAULT_BUTTON_STYLE = 'z-10 h-[34px] w-[34px] cursor-pointer';
   const CARD_DEFAULT_BUTTON_STYLE_ATTACHED = 'absolute bottom-0';
+
+  useEffect(() => {
+    setStartedAt(new Date());
+  }, []);
+
+  const pathname = usePathname();
+  const pathArray = pathname.split('/')[1];
+  const searchParams = useSearchParams();
+  const source = (() => {
+    const param = searchParams.get('source');
+    if (
+      param === 'direct' ||
+      param === 'qr' ||
+      param === 'link' ||
+      param === 'tag'
+    ) {
+      return param;
+    }
+    return null;
+  })();
+
+  const { handleClick, socialLinks } = useInteractionTracker({
+    slug: pathArray,
+    source,
+    startedAt,
+  });
 
   return (
     <div className='relative mb-4 flex w-full flex-col items-center justify-center'>
@@ -25,7 +54,24 @@ const FlipCard = ({ attached }: FlipCardParam) => {
             isFlipped && 'rotate-y-180'
           )}
         >
-          <div className={CARD_DEFAULT_STYLE}>front</div>
+          <div className={CARD_DEFAULT_STYLE}>
+            <div className='flex flex-col items-center justify-center'>
+              {socialLinks &&
+                socialLinks.map(({ platform, url }) => {
+                  if (!url) return;
+                  return (
+                    <button
+                      onClick={() =>
+                        handleClick({ url, elementName: platform })
+                      }
+                      key={platform}
+                    >
+                      {platform}
+                    </button>
+                  );
+                })}
+            </div>
+          </div>
           <div className={clsx(CARD_DEFAULT_STYLE, 'rotate-y-180')}>back</div>
         </div>
       </div>

--- a/src/constants/query-key.ts
+++ b/src/constants/query-key.ts
@@ -3,4 +3,7 @@ export const QUERY_KEY = {
   WEEK_CHART: 'week-chart',
   CLICK_TOTAL_CHART: 'click-total-chart',
   CARD_SELECT_LIST: 'card-select-list',
+  CARD_INTERACTION: 'card-interaction',
+  USER_IP: 'user-ip',
+  CARD_SOCIAL_LIST: 'card-social-list',
 };

--- a/src/constants/tables.constant.ts
+++ b/src/constants/tables.constant.ts
@@ -3,12 +3,21 @@ export const TABLES = {
   CARD_VIEWS: 'card_views',
   CARDS: 'cards',
   TEMPLATES: 'templates',
+  LINKS: 'links',
 } as const;
 
 export const SUB_TABLES = {
   DAILY_CARD_VIEWS: 'daily_card_views',
   DAILY_CARD_SAVES: 'daily_card_saves',
 } as const;
+
+export const STORAGE = {
+  CARDS: 'cards',
+  QRCODES: 'qrcodes',
+  BGIMG: 'bgimg',
+  TEMPLATES: 'templates',
+  ICONS: 'icons',
+};
 
 export const DB_COLUMNS = {
   CARD_VIEWS: {
@@ -38,6 +47,13 @@ export const DB_COLUMNS = {
     UPDATED_AT: 'updated_at',
     FRONT_IMG_URL: 'frontImgURL',
     BACK_IMG_URL: 'backImgURL',
+  },
+  LINKS: {
+    ID: 'id',
+    CARD_ID: 'card_id',
+    PLATFOMR: 'platform',
+    URL: 'url',
+    ICON_PATH: 'icon_path',
   },
   DAILY_CARD_VIEWS: {
     VIEW_DATE: 'view_date',

--- a/src/constants/tables.constant.ts
+++ b/src/constants/tables.constant.ts
@@ -51,7 +51,7 @@ export const DB_COLUMNS = {
   LINKS: {
     ID: 'id',
     CARD_ID: 'card_id',
-    PLATFOMR: 'platform',
+    PLATFORM: 'platform',
     URL: 'url',
     ICON_PATH: 'icon_path',
   },

--- a/src/hooks/mutations/use-init-session.ts
+++ b/src/hooks/mutations/use-init-session.ts
@@ -109,7 +109,7 @@ export const useLogInteractionMutation = (
         startedAt: formatToDateString(startedAtDate),
         viewerIp,
         sessionId: effectiveSessionId,
-        source: source as 'direct' | 'qr' | 'link' | 'iframe' | null,
+        source: source as 'direct' | 'qr' | 'link' | 'tag' | null | undefined,
       });
     },
   });

--- a/src/hooks/mutations/use-init-session.ts
+++ b/src/hooks/mutations/use-init-session.ts
@@ -109,7 +109,7 @@ export const useLogInteractionMutation = (
         startedAt: formatToDateString(startedAtDate),
         viewerIp,
         sessionId: effectiveSessionId,
-        source: source as 'direct' | 'qr' | 'link' | 'tag' | null | undefined,
+        source: source as 'direct' | 'qr' | 'link' | 'tag' | null,
       });
     },
   });

--- a/src/hooks/mutations/use-init-session.ts
+++ b/src/hooks/mutations/use-init-session.ts
@@ -3,14 +3,20 @@ import {
   endSession,
   logInteraction,
 } from '@/apis/interaction';
-import { formatToDateString } from '@/utils/interaction/format-date';
 import { useMutation } from '@tanstack/react-query';
+import { formatToDateString } from '@/utils/interaction/format-date';
 
 interface SessionData {
   sessionId: string;
   startedAt: string;
 }
 
+/**
+ * 세션 초기화
+ *
+ * @param startedAt 세션 시작 시간
+ * @returns
+ */
 export const useInitSessionMutation = (startedAt: Date | null) => {
   return useMutation({
     mutationFn: async (): Promise<SessionData> => {
@@ -44,6 +50,9 @@ export const useInitSessionMutation = (startedAt: Date | null) => {
   });
 };
 
+/**
+ * 세션 종료를 위한 훅
+ */
 export const useEndSessionMutation = () => {
   return useMutation({
     mutationFn: ({
@@ -58,6 +67,15 @@ export const useEndSessionMutation = () => {
   });
 };
 
+/**
+ * 사용자 인터랙션 로깅
+ *
+ * @param cardId 명함 ID
+ * @param viewerIp 사용자 IP
+ * @param source 접근 출처 (direct, qr, link, tag 등)
+ * @param startedAtDate 시작 시간
+ * @returns
+ */
 export const useLogInteractionMutation = (
   cardId: string,
   viewerIp: string | undefined,
@@ -97,6 +115,9 @@ export const useLogInteractionMutation = (
   });
 };
 
+/**
+ * 명함 이미지 다운로드
+ */
 export const useDownloadCardImageMutation = () => {
   return useMutation({
     mutationFn: downloadCardImage,

--- a/src/hooks/mutations/use-init-session.ts
+++ b/src/hooks/mutations/use-init-session.ts
@@ -1,0 +1,104 @@
+import {
+  downloadCardImage,
+  endSession,
+  logInteraction,
+} from '@/apis/interaction';
+import { formatToDateString } from '@/utils/interaction/format-date';
+import { useMutation } from '@tanstack/react-query';
+
+interface SessionData {
+  sessionId: string;
+  startedAt: string;
+}
+
+export const useInitSessionMutation = (startedAt: Date | null) => {
+  return useMutation({
+    mutationFn: async (): Promise<SessionData> => {
+      const existingSessionId =
+        sessionStorage.getItem('currentSessionId') ||
+        localStorage.getItem('backup_session_id') ||
+        null;
+
+      if (!startedAt) {
+        throw new Error('startedAt is required to initialize a session');
+      }
+
+      if (existingSessionId) {
+        return {
+          sessionId: existingSessionId,
+          startedAt:
+            sessionStorage.getItem('session_started_at') ||
+            formatToDateString(startedAt),
+        };
+      }
+
+      const startTime = formatToDateString(startedAt);
+      const uuid = crypto.randomUUID();
+
+      sessionStorage.setItem('currentSessionId', uuid);
+      sessionStorage.setItem('session_started_at', startTime);
+      localStorage.setItem('backup_session_id', uuid);
+
+      return { sessionId: uuid, startedAt: startTime };
+    },
+  });
+};
+
+export const useEndSessionMutation = () => {
+  return useMutation({
+    mutationFn: ({
+      reason,
+      sessionId,
+    }: {
+      reason: string;
+      sessionId: string;
+    }) => {
+      return endSession(sessionId, reason);
+    },
+  });
+};
+
+export const useLogInteractionMutation = (
+  cardId: string,
+  viewerIp: string | undefined,
+  source: 'direct' | 'qr' | 'link' | 'tag' | null | undefined,
+  startedAtDate: Date | null
+) => {
+  return useMutation({
+    mutationFn: ({
+      elementName,
+      type,
+    }: {
+      elementName: string | null;
+      type: 'click' | 'save' | null | undefined;
+    }) => {
+      if (!viewerIp || !cardId) throw new Error('Missing required data');
+
+      const effectiveSessionId =
+        sessionStorage.getItem('currentSessionId') ||
+        localStorage.getItem('backup_session_id') ||
+        null;
+      if (!startedAtDate) {
+        throw new Error('startedAt is required to initialize a session');
+      }
+
+      if (!effectiveSessionId) throw new Error('No session ID available');
+
+      return logInteraction({
+        cardId,
+        elementName,
+        type,
+        startedAt: formatToDateString(startedAtDate),
+        viewerIp,
+        sessionId: effectiveSessionId,
+        source: source as 'direct' | 'qr' | 'link' | 'iframe' | null,
+      });
+    },
+  });
+};
+
+export const useDownloadCardImageMutation = () => {
+  return useMutation({
+    mutationFn: downloadCardImage,
+  });
+};

--- a/src/hooks/mutations/use-init-session.ts
+++ b/src/hooks/mutations/use-init-session.ts
@@ -118,8 +118,11 @@ export const useLogInteractionMutation = (
 /**
  * 명함 이미지 다운로드
  */
-export const useDownloadCardImageMutation = () => {
+export const useDownloadCardImageMutation = (
+  cardId: string,
+  fileName: string
+) => {
   return useMutation({
-    mutationFn: downloadCardImage,
+    mutationFn: () => downloadCardImage(cardId, fileName),
   });
 };

--- a/src/hooks/queries/use-card-interaction.ts
+++ b/src/hooks/queries/use-card-interaction.ts
@@ -10,7 +10,7 @@ import { useQuery } from '@tanstack/react-query';
  */
 const useCardInteraction = (slug: string) => {
   return useQuery({
-    queryKey: [QUERY_KEY.CARD_INTERACTION],
+    queryKey: [QUERY_KEY.CARD_INTERACTION, slug],
     queryFn: async () => getCardId(slug),
     enabled: !!slug, // slug가 존재할 때만 쿼리 활성화
   });

--- a/src/hooks/queries/use-card-interaction.ts
+++ b/src/hooks/queries/use-card-interaction.ts
@@ -2,11 +2,17 @@ import { getCardId } from '@/apis/card-interaction';
 import { QUERY_KEY } from '@/constants/query-key';
 import { useQuery } from '@tanstack/react-query';
 
+/**
+ * 슬러그를 기반으로 명함 ID를 조회하는 쿼리 훅
+ *
+ * @param slug 명함 슬러그 문자열
+ * @returns
+ */
 const useCardInteraction = (slug: string) => {
   return useQuery({
     queryKey: [QUERY_KEY.CARD_INTERACTION],
     queryFn: async () => getCardId(slug),
-    enabled: !!slug,
+    enabled: !!slug, // slug가 존재할 때만 쿼리 활성화
   });
 };
 

--- a/src/hooks/queries/use-card-interaction.ts
+++ b/src/hooks/queries/use-card-interaction.ts
@@ -1,0 +1,13 @@
+import { getCardId } from '@/apis/card-interaction';
+import { QUERY_KEY } from '@/constants/query-key';
+import { useQuery } from '@tanstack/react-query';
+
+const useCardInteraction = (slug: string) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.CARD_INTERACTION],
+    queryFn: async () => getCardId(slug),
+    enabled: !!slug,
+  });
+};
+
+export default useCardInteraction;

--- a/src/hooks/queries/use-card-social-list.ts
+++ b/src/hooks/queries/use-card-social-list.ts
@@ -10,7 +10,7 @@ import { useQuery } from '@tanstack/react-query';
  */
 const useCardSocialList = (card_id: string) => {
   return useQuery({
-    queryKey: [QUERY_KEY.CARD_SOCIAL_LIST],
+    queryKey: [QUERY_KEY.CARD_SOCIAL_LIST, card_id],
     queryFn: async () => getCardSocialLists(card_id),
     enabled: !!card_id, // card_id가 존재할 때만 쿼리 활성화
   });

--- a/src/hooks/queries/use-card-social-list.ts
+++ b/src/hooks/queries/use-card-social-list.ts
@@ -2,11 +2,17 @@ import { getCardSocialLists } from '@/apis/card-social-list';
 import { QUERY_KEY } from '@/constants/query-key';
 import { useQuery } from '@tanstack/react-query';
 
+/**
+ * 명함의 소셜 링크 목록
+ *
+ * @param card_id 소셜 링크를 조회할 명함 ID
+ * @returns
+ */
 const useCardSocialList = (card_id: string) => {
   return useQuery({
     queryKey: [QUERY_KEY.CARD_SOCIAL_LIST],
     queryFn: async () => getCardSocialLists(card_id),
-    enabled: !!card_id,
+    enabled: !!card_id, // card_id가 존재할 때만 쿼리 활성화
   });
 };
 

--- a/src/hooks/queries/use-card-social-list.ts
+++ b/src/hooks/queries/use-card-social-list.ts
@@ -1,0 +1,13 @@
+import { getCardSocialLists } from '@/apis/card-social-list';
+import { QUERY_KEY } from '@/constants/query-key';
+import { useQuery } from '@tanstack/react-query';
+
+const useCardSocialList = (card_id: string) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.CARD_SOCIAL_LIST],
+    queryFn: async () => getCardSocialLists(card_id),
+    enabled: !!card_id,
+  });
+};
+
+export default useCardSocialList;

--- a/src/hooks/queries/use-ip-address.ts
+++ b/src/hooks/queries/use-ip-address.ts
@@ -2,11 +2,16 @@ import { getIpAddress } from '@/apis/interaction';
 import { QUERY_KEY } from '@/constants/query-key';
 import { useQuery } from '@tanstack/react-query';
 
+/**
+ * 사용자 IP 주소를 조회하는 쿼리 훅
+ *
+ * @returns IP 주소 정보를 포함한 쿼리 결과
+ */
 export const useIpAddressQuery = () => {
   return useQuery({
     queryKey: [QUERY_KEY.USER_IP],
     queryFn: getIpAddress,
-    staleTime: Infinity,
-    retry: 3,
+    staleTime: Infinity, // IP는 세션 동안 변경되지 않으므로 무한 캐시
+    retry: 3, // 실패 시 최대 3번 재시도
   });
 };

--- a/src/hooks/queries/use-ip-address.ts
+++ b/src/hooks/queries/use-ip-address.ts
@@ -1,0 +1,12 @@
+import { getIpAddress } from '@/apis/interaction';
+import { QUERY_KEY } from '@/constants/query-key';
+import { useQuery } from '@tanstack/react-query';
+
+export const useIpAddressQuery = () => {
+  return useQuery({
+    queryKey: [QUERY_KEY.USER_IP],
+    queryFn: getIpAddress,
+    staleTime: Infinity,
+    retry: 3,
+  });
+};

--- a/src/hooks/use-interaction-tracker.ts
+++ b/src/hooks/use-interaction-tracker.ts
@@ -24,6 +24,9 @@ interface SocialLink {
   url: string | URL | undefined;
 }
 
+/**
+ * 인터랙션 추적 훅
+ */
 export const useInteractionTracker = ({
   slug,
   source,
@@ -48,11 +51,15 @@ export const useInteractionTracker = ({
   const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastActivityRef = useRef<Date | null>(null);
 
+  // 세션 초기화
   useEffect(() => {
     if (!ip || !cardId) return;
     sessionInitMutation.mutate();
   }, [ip, cardId]);
 
+  /**
+   * 활동 업데이트
+   */
   const updateActivity = () => {
     lastActivityRef.current = new Date();
     if (inactivityTimerRef.current) {
@@ -69,6 +76,7 @@ export const useInteractionTracker = ({
     );
   };
 
+  // 활동 이벤트 설정
   useEffect(() => {
     const sessionId = getEffectiveSessionId();
     if (!sessionId) return;
@@ -119,6 +127,9 @@ export const useInteractionTracker = ({
     };
   }, []);
 
+  /**
+   * 이미지 저장 처리
+   */
   const handleSaveImg = async () => {
     try {
       const data = await downloadCardImageMutation.mutateAsync();
@@ -140,6 +151,9 @@ export const useInteractionTracker = ({
     }
   };
 
+  /**
+   * vCard 저장 처리
+   */
   const handleSaveVCard = async () => {
     try {
       logInteractionMutation.mutate({ elementName: 'vcard', type: 'save' });
@@ -149,6 +163,9 @@ export const useInteractionTracker = ({
     }
   };
 
+  /**
+   * 소셜 링크 클릭 처리
+   */
   const handleClick = async ({ url, elementName }: SocialLink) => {
     logInteractionMutation.mutate({ elementName, type: 'click' });
     window.open(url, '_blank');

--- a/src/hooks/use-interaction-tracker.ts
+++ b/src/hooks/use-interaction-tracker.ts
@@ -46,7 +46,11 @@ export const useInteractionTracker = ({
     source,
     startedAt
   );
-  const downloadCardImageMutation = useDownloadCardImageMutation();
+  // 더미 데이터 추가
+  const downloadCardImageMutation = useDownloadCardImageMutation(
+    'aabc7dc1-3991-4985-95bf-998a5425e0c8',
+    'card_test'
+  );
 
   const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastActivityRef = useRef<Date | null>(null);

--- a/src/hooks/use-interaction-tracker.ts
+++ b/src/hooks/use-interaction-tracker.ts
@@ -1,0 +1,166 @@
+import { useEffect, useRef } from 'react';
+import { useIpAddressQuery } from './queries/use-ip-address';
+import {
+  useDownloadCardImageMutation,
+  useEndSessionMutation,
+  useInitSessionMutation,
+  useLogInteractionMutation,
+} from './mutations/use-init-session';
+import {
+  getEffectiveSessionId,
+  storePendingSessionEnd,
+} from '@/utils/interaction/session-util';
+import useCardInteraction from './queries/use-card-interaction';
+import useCardSocialList from './queries/use-card-social-list';
+
+interface InteractionProps {
+  slug: string;
+  source: 'direct' | 'qr' | 'link' | 'tag' | null | undefined;
+  startedAt: Date | null;
+}
+
+interface SocialLink {
+  elementName: string | null;
+  url: string | URL | undefined;
+}
+
+export const useInteractionTracker = ({
+  slug,
+  source,
+  startedAt,
+}: InteractionProps) => {
+  const { data: ip } = useIpAddressQuery();
+
+  const sessionInitMutation = useInitSessionMutation(startedAt);
+  const endSessionMutation = useEndSessionMutation();
+  const { data } = useCardInteraction(slug);
+  const cardId = data;
+  const { data: socialLinks } = useCardSocialList(cardId || '');
+
+  const logInteractionMutation = useLogInteractionMutation(
+    cardId || '',
+    ip,
+    source,
+    startedAt
+  );
+  const downloadCardImageMutation = useDownloadCardImageMutation();
+
+  const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const lastActivityRef = useRef<Date | null>(null);
+
+  useEffect(() => {
+    if (!ip || !cardId) return;
+    sessionInitMutation.mutate();
+  }, [ip, cardId]);
+
+  const updateActivity = () => {
+    lastActivityRef.current = new Date();
+    if (inactivityTimerRef.current) {
+      clearTimeout(inactivityTimerRef.current);
+    }
+    inactivityTimerRef.current = setTimeout(
+      () => {
+        const sessionId = getEffectiveSessionId();
+        if (sessionId) {
+          endSessionMutation.mutate({ reason: 'inactive', sessionId });
+        }
+      },
+      30 * 60 * 1000
+    );
+  };
+
+  useEffect(() => {
+    const sessionId = getEffectiveSessionId();
+    if (!sessionId) return;
+
+    const activityEvents = [
+      'mousemove',
+      'mousedown',
+      'keypress',
+      'scroll',
+      'touchstart',
+    ];
+
+    activityEvents.forEach((event) => {
+      window.addEventListener(event, updateActivity);
+    });
+
+    updateActivity();
+
+    const handleBeforeUnload = () => {
+      const currentSessionId = getEffectiveSessionId();
+      if (currentSessionId) {
+        storePendingSessionEnd(currentSessionId);
+        endSessionMutation.mutate({
+          reason: 'page-exit',
+          sessionId: currentSessionId,
+        });
+      }
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      activityEvents.forEach((event) => {
+        window.removeEventListener(event, updateActivity);
+      });
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+
+      if (inactivityTimerRef.current) {
+        clearTimeout(inactivityTimerRef.current);
+      }
+
+      const currentSessionId = getEffectiveSessionId();
+      if (currentSessionId) {
+        endSessionMutation.mutate({
+          reason: 'route-change',
+          sessionId: currentSessionId,
+        });
+      }
+    };
+  }, []);
+
+  const handleSaveImg = async () => {
+    try {
+      const data = await downloadCardImageMutation.mutateAsync();
+
+      const blob = new Blob([data], { type: 'image/jpeg' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'text.jpg';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+
+      logInteractionMutation.mutate({ elementName: 'image', type: 'save' });
+      updateActivity();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleSaveVCard = async () => {
+    try {
+      logInteractionMutation.mutate({ elementName: 'vcard', type: 'save' });
+      updateActivity();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleClick = async ({ url, elementName }: SocialLink) => {
+    logInteractionMutation.mutate({ elementName, type: 'click' });
+    window.open(url, '_blank');
+    updateActivity();
+  };
+
+  return {
+    handleClick,
+    handleSaveImg,
+    socialLinks,
+    handleSaveVCard,
+    isLoading: !ip || sessionInitMutation.isPending,
+    isError: sessionInitMutation.isError || logInteractionMutation.isError,
+  };
+};

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -4,370 +4,370 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[]
+  | Json[];
 
 export type Database = {
   public: {
     Tables: {
       card_views: {
         Row: {
-          card_id: string
-          duration: number | null
-          element_name: string | null
-          end_at: string | null
-          id: string
-          occurred_at: string | null
-          session_id: string | null
-          source: Database["public"]["Enums"]["card_views_source"] | null
-          started_at: string | null
-          type: Database["public"]["Enums"]["interactions_type"] | null
-          viewer_id: string | null
-          viewer_ip: string | null
-        }
+          card_id: string;
+          duration: number | null;
+          element_name: string | null;
+          end_at: string | null;
+          id: string;
+          occurred_at: string | null;
+          session_id: string | null;
+          source: Database['public']['Enums']['card_views_source'] | null;
+          started_at: string | null;
+          type: Database['public']['Enums']['interactions_type'] | null;
+          viewer_id: string | null;
+          viewer_ip: string | null;
+        };
         Insert: {
-          card_id: string
-          duration?: number | null
-          element_name?: string | null
-          end_at?: string | null
-          id?: string
-          occurred_at?: string | null
-          session_id?: string | null
-          source?: Database["public"]["Enums"]["card_views_source"] | null
-          started_at?: string | null
-          type?: Database["public"]["Enums"]["interactions_type"] | null
-          viewer_id?: string | null
-          viewer_ip?: string | null
-        }
+          card_id: string;
+          duration?: number | null;
+          element_name?: string | null;
+          end_at?: string | null;
+          id?: string;
+          occurred_at?: string | null;
+          session_id?: string | null;
+          source?: Database['public']['Enums']['card_views_source'] | null;
+          started_at?: string | null;
+          type?: Database['public']['Enums']['interactions_type'] | null;
+          viewer_id?: string | null;
+          viewer_ip?: string | null;
+        };
         Update: {
-          card_id?: string
-          duration?: number | null
-          element_name?: string | null
-          end_at?: string | null
-          id?: string
-          occurred_at?: string | null
-          session_id?: string | null
-          source?: Database["public"]["Enums"]["card_views_source"] | null
-          started_at?: string | null
-          type?: Database["public"]["Enums"]["interactions_type"] | null
-          viewer_id?: string | null
-          viewer_ip?: string | null
-        }
+          card_id?: string;
+          duration?: number | null;
+          element_name?: string | null;
+          end_at?: string | null;
+          id?: string;
+          occurred_at?: string | null;
+          session_id?: string | null;
+          source?: Database['public']['Enums']['card_views_source'] | null;
+          started_at?: string | null;
+          type?: Database['public']['Enums']['interactions_type'] | null;
+          viewer_id?: string | null;
+          viewer_ip?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "card_views_card_id_fkey"
-            columns: ["card_id"]
-            isOneToOne: false
-            referencedRelation: "cards"
-            referencedColumns: ["id"]
+            foreignKeyName: 'card_views_card_id_fkey';
+            columns: ['card_id'];
+            isOneToOne: false;
+            referencedRelation: 'cards';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "card_views_viewer_id_fkey"
-            columns: ["viewer_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'card_views_viewer_id_fkey';
+            columns: ['viewer_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       cards: {
         Row: {
-          back_content: Json | null
-          backImgURL: string | null
-          created_at: string
-          front_content: Json | null
-          frontImgURL: string | null
-          id: string
-          slug: string
-          status: Database["public"]["Enums"]["cards_status"] | null
-          template_id: string
-          title: string
-          updated_at: string | null
-          user_id: string | null
-        }
+          back_content: Json | null;
+          backImgURL: string | null;
+          created_at: string;
+          front_content: Json | null;
+          frontImgURL: string | null;
+          id: string;
+          slug: string;
+          status: Database['public']['Enums']['cards_status'] | null;
+          template_id: string;
+          title: string;
+          updated_at: string | null;
+          user_id: string | null;
+        };
         Insert: {
-          back_content?: Json | null
-          backImgURL?: string | null
-          created_at?: string
-          front_content?: Json | null
-          frontImgURL?: string | null
-          id?: string
-          slug: string
-          status?: Database["public"]["Enums"]["cards_status"] | null
-          template_id: string
-          title: string
-          updated_at?: string | null
-          user_id?: string | null
-        }
+          back_content?: Json | null;
+          backImgURL?: string | null;
+          created_at?: string;
+          front_content?: Json | null;
+          frontImgURL?: string | null;
+          id?: string;
+          slug: string;
+          status?: Database['public']['Enums']['cards_status'] | null;
+          template_id: string;
+          title: string;
+          updated_at?: string | null;
+          user_id?: string | null;
+        };
         Update: {
-          back_content?: Json | null
-          backImgURL?: string | null
-          created_at?: string
-          front_content?: Json | null
-          frontImgURL?: string | null
-          id?: string
-          slug?: string
-          status?: Database["public"]["Enums"]["cards_status"] | null
-          template_id?: string
-          title?: string
-          updated_at?: string | null
-          user_id?: string | null
-        }
+          back_content?: Json | null;
+          backImgURL?: string | null;
+          created_at?: string;
+          front_content?: Json | null;
+          frontImgURL?: string | null;
+          id?: string;
+          slug?: string;
+          status?: Database['public']['Enums']['cards_status'] | null;
+          template_id?: string;
+          title?: string;
+          updated_at?: string | null;
+          user_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "cards_template_id_fkey"
-            columns: ["template_id"]
-            isOneToOne: false
-            referencedRelation: "templates"
-            referencedColumns: ["id"]
+            foreignKeyName: 'cards_template_id_fkey';
+            columns: ['template_id'];
+            isOneToOne: false;
+            referencedRelation: 'templates';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "cards_user_id_fkey1"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: 'cards_user_id_fkey1';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       links: {
         Row: {
-          card_id: string
-          icon_path: string | null
-          id: string
-          platform: string | null
-          url: string | null
-        }
+          card_id: string;
+          icon_path: string | null;
+          id: string;
+          platform: string | null;
+          url: string | null;
+        };
         Insert: {
-          card_id?: string
-          icon_path?: string | null
-          id?: string
-          platform?: string | null
-          url?: string | null
-        }
+          card_id?: string;
+          icon_path?: string | null;
+          id?: string;
+          platform?: string | null;
+          url?: string | null;
+        };
         Update: {
-          card_id?: string
-          icon_path?: string | null
-          id?: string
-          platform?: string | null
-          url?: string | null
-        }
+          card_id?: string;
+          icon_path?: string | null;
+          id?: string;
+          platform?: string | null;
+          url?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "links_card_id_fkey"
-            columns: ["card_id"]
-            isOneToOne: false
-            referencedRelation: "cards"
-            referencedColumns: ["id"]
+            foreignKeyName: 'links_card_id_fkey';
+            columns: ['card_id'];
+            isOneToOne: false;
+            referencedRelation: 'cards';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       templates: {
         Row: {
-          id: string
-          name: string
-          structure: Json
-          style: Database["public"]["Enums"]["templates_style"] | null
-          thumbnail: string | null
-        }
+          id: string;
+          name: string;
+          structure: Json;
+          style: Database['public']['Enums']['templates_style'] | null;
+          thumbnail: string | null;
+        };
         Insert: {
-          id?: string
-          name: string
-          structure: Json
-          style?: Database["public"]["Enums"]["templates_style"] | null
-          thumbnail?: string | null
-        }
+          id?: string;
+          name: string;
+          structure: Json;
+          style?: Database['public']['Enums']['templates_style'] | null;
+          thumbnail?: string | null;
+        };
         Update: {
-          id?: string
-          name?: string
-          structure?: Json
-          style?: Database["public"]["Enums"]["templates_style"] | null
-          thumbnail?: string | null
-        }
-        Relationships: []
-      }
+          id?: string;
+          name?: string;
+          structure?: Json;
+          style?: Database['public']['Enums']['templates_style'] | null;
+          thumbnail?: string | null;
+        };
+        Relationships: [];
+      };
       users: {
         Row: {
-          created_at: string
-          email: string
-          id: string
-          nick_name: string
-        }
+          created_at: string;
+          email: string;
+          id: string;
+          nick_name: string;
+        };
         Insert: {
-          created_at?: string
-          email: string
-          id?: string
-          nick_name: string
-        }
+          created_at?: string;
+          email: string;
+          id?: string;
+          nick_name: string;
+        };
         Update: {
-          created_at?: string
-          email?: string
-          id?: string
-          nick_name?: string
-        }
-        Relationships: []
-      }
-    }
+          created_at?: string;
+          email?: string;
+          id?: string;
+          nick_name?: string;
+        };
+        Relationships: [];
+      };
+    };
     Views: {
       daily_card_saves: {
         Row: {
-          card_id: string | null
-          save_date: string | null
-          unique_saves: number | null
-        }
+          card_id: string | null;
+          save_date: string | null;
+          unique_saves: number | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "card_views_card_id_fkey"
-            columns: ["card_id"]
-            isOneToOne: false
-            referencedRelation: "cards"
-            referencedColumns: ["id"]
+            foreignKeyName: 'card_views_card_id_fkey';
+            columns: ['card_id'];
+            isOneToOne: false;
+            referencedRelation: 'cards';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       daily_card_views: {
         Row: {
-          card_id: string | null
-          unique_sessions: number | null
-          view_date: string | null
-        }
+          card_id: string | null;
+          unique_sessions: number | null;
+          view_date: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "card_views_card_id_fkey"
-            columns: ["card_id"]
-            isOneToOne: false
-            referencedRelation: "cards"
-            referencedColumns: ["id"]
+            foreignKeyName: 'card_views_card_id_fkey';
+            columns: ['card_id'];
+            isOneToOne: false;
+            referencedRelation: 'cards';
+            referencedColumns: ['id'];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Functions: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Enums: {
-      card_views_source: "direct" | "qr" | "link" | "iframe"
-      cards_status: "draft" | "published"
-      interactions_type: "click" | "save"
-      templates_style: "simple" | "trendy"
-    }
+      card_views_source: 'direct' | 'qr' | 'link' | 'tag';
+      cards_status: 'draft' | 'published';
+      interactions_type: 'click' | 'save';
+      templates_style: 'simple' | 'trendy';
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DefaultSchema = Database[Extract<keyof Database, "public">]
+type DefaultSchema = Database[Extract<keyof Database, 'public'>];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
     | { schema: keyof Database },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
-    ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    ? keyof (Database[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+        Database[DefaultSchemaTableNameOrOptions['schema']]['Views'])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+  ? (Database[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+      Database[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R;
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])
+    ? (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof Database },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
-    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof Database[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
-  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+  ? Database[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I;
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof Database },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
-    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof Database[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
-  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+  ? Database[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U;
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
+    | keyof DefaultSchema['Enums']
     | { schema: keyof Database },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
-    ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    ? keyof Database[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+  ? Database[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
+    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
+    | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
-    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+  ? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+    : never;
 
 export const Constants = {
   public: {
     Enums: {
-      card_views_source: ["direct", "qr", "link", "iframe"],
-      cards_status: ["draft", "published"],
-      interactions_type: ["click", "save"],
-      templates_style: ["simple", "trendy"],
+      card_views_source: ['direct', 'qr', 'link', 'tag'],
+      cards_status: ['draft', 'published'],
+      interactions_type: ['click', 'save'],
+      templates_style: ['simple', 'trendy'],
     },
   },
-} as const
+} as const;

--- a/src/utils/interaction/format-date.ts
+++ b/src/utils/interaction/format-date.ts
@@ -10,7 +10,12 @@ export const formatToDateString = (date: Date): string => {
   const day = date.getDate().toString().padStart(2, '0');
 
   const formattedDate = `${year}-${month}-${day}`;
-  const formattedTime = `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`;
+
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const seconds = date.getSeconds().toString().padStart(2, '0');
+
+  const formattedTime = `${hours}:${minutes}:${seconds}`;
 
   return formattedDate + ' ' + formattedTime;
 };

--- a/src/utils/interaction/format-date.ts
+++ b/src/utils/interaction/format-date.ts
@@ -1,0 +1,16 @@
+/**
+ * 주어진 날짜를 yyyy-mm-dd 형식으로 변환하는 함수입니다.
+ *
+ * @param {Date} date - 변환할 Date 객체.
+ * @returns {string} yyyy-mm-dd 형식으로 변환된 날짜 문자열.
+ */
+export const formatToDateString = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+
+  const formattedDate = `${year}-${month}-${day}`;
+  const formattedTime = `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`;
+
+  return formattedDate + ' ' + formattedTime;
+};

--- a/src/utils/interaction/session-util.ts
+++ b/src/utils/interaction/session-util.ts
@@ -1,0 +1,25 @@
+import { formatToDateString } from './format-date';
+
+export const getEffectiveSessionId = (): string | null => {
+  return (
+    sessionStorage.getItem('currentSessionId') ||
+    localStorage.getItem('backup_session_id') ||
+    null
+  );
+};
+
+export const storePendingSessionEnd = (sessionId: string): void => {
+  localStorage.setItem(
+    'pending_end_session',
+    JSON.stringify({
+      session_id: sessionId,
+      end_at: formatToDateString(new Date()),
+      timestamp: Date.now(),
+    })
+  );
+};
+
+export const clearSessionData = (): void => {
+  sessionStorage.removeItem('currentSessionId');
+  sessionStorage.removeItem('session_started_at');
+};

--- a/src/utils/interaction/session-util.ts
+++ b/src/utils/interaction/session-util.ts
@@ -1,5 +1,8 @@
 import { formatToDateString } from './format-date';
 
+/**
+ * 유효한 세션 ID를 가져옴
+ */
 export const getEffectiveSessionId = (): string | null => {
   return (
     sessionStorage.getItem('currentSessionId') ||
@@ -8,6 +11,9 @@ export const getEffectiveSessionId = (): string | null => {
   );
 };
 
+/**
+ * 세션 종료 데이터 저장
+ */
 export const storePendingSessionEnd = (sessionId: string): void => {
   localStorage.setItem(
     'pending_end_session',
@@ -19,6 +25,9 @@ export const storePendingSessionEnd = (sessionId: string): void => {
   );
 };
 
+/**
+ * 세션 데이터 삭제
+ */
 export const clearSessionData = (): void => {
   sessionStorage.removeItem('currentSessionId');
   sessionStorage.removeItem('session_started_at');


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closed #74

<br>

## 📝 작업 내용

- 날짜 형식 반환 함수 및 세션 관리 유틸함수 추가
- 명함 인터렉션 히트맵(노선, 깃허브, 카톡, 링크드인, 카톡)
- 키보드 / 마우스 30분간 반응이 없을 경우 및 창을 닫을경우 end_at 변경

<br>

## 🖼 스크린샷

https://github.com/user-attachments/assets/5a305f16-ac32-42d8-9fed-5a93284ca3d3



<br>

## 💬 리뷰 요구사항

> 리팩토링까지 진행하면서 파일수가 많아졌습니다..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 카드 ID를 슬러그를 기반으로 검색하는 기능이 추가되었습니다.
	- 비즈니스 카드에 연결된 소셜 링크 목록을 가져오는 기능이 추가되었습니다.
	- 사용자 IP 주소를 가져오는 기능이 도입되었습니다.
	- 사용자 상호작용을 기록하고 세션을 관리하는 기능이 강화되었습니다.
	- 카드 이미지 다운로드 기능이 추가되었습니다.
	- FlipCard 컴포넌트에 소셜 링크 버튼이 추가되어, 관련 사이트로 손쉽게 이동할 수 있습니다.
	- 세션 초기화 및 종료, 상호작용 로깅을 위한 사용자 정의 훅이 추가되었습니다.
	- 사용자 상호작용을 추적하는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->