### PR TITLE
[FEAT] #195 명함 생성 제한 

### DIFF
--- a/src/apis/card-interaction.ts
+++ b/src/apis/card-interaction.ts
@@ -74,3 +74,50 @@ export const getCardTitle = async (cardId: string) => {
 
   return data;
 };
+
+/**
+ * 사용자의 명함 개수를 조회하는 함수
+ *
+ * @description
+ * 사용자가 보유한 명함의 총 개수를 조회
+ * @param userId - 조회하려는 사용자의 고유 ID
+ * @returns Promise<number> - 사용자가 보유한 명함의 개수 (0 이상의 정수)
+ *
+ * @throws {Error}
+ * - RLS 정책 위반 시: "최대 3개의 명함만 생성할 수 있습니다." 메시지와 함께 에러 발생
+ * - 기타 데이터베이스 에러: Supabase에서 발생한 원본 에러를 그대로 전달
+ */
+export const getCardCount = async (userId: string) => {
+  const supabase = await createClient();
+
+  // 명함 테이블에서 사용자의 명함 개수 조회
+  const { count, error } = await supabase
+    .from(TABLES.CARDS) 
+    .select('*', {
+      count: 'exact', // 정확한 개수 조회
+      head: true, // 실제 데이터는 조회하지 않고 개수만 반환
+    })
+    .eq(DB_COLUMNS.CARDS.USER_ID, userId); // 사용자 ID로 필터링
+
+  if (error) {
+    if (error.code === '42501') {
+      // RLS 정책 위반 에러 코드
+      throw new Error('최대 3개의 명함만 생성할 수 있습니다.');
+    }
+    throw error; // 기타 데이터베이스 에러는 그대로 전달
+  }
+
+  // 명함이 없는 경우 0 반환, 그 외에는 조회된 개수 반환
+  return count || 0;
+};
+
+/* @example
+* ```typescript
+* try {
+*   const count = await getCardCount('user-123');
+*   console.log(`사용자가 보유한 명함 개수: ${count}`);
+* } catch (error) {
+*   console.error('명함 개수 조회 중 에러 발생:', error);
+* }
+* ```
+*/

--- a/src/components/dashboard/create-new-card.tsx
+++ b/src/components/dashboard/create-new-card.tsx
@@ -1,13 +1,66 @@
+'use client';
+
 import { ROUTES } from '@/constants/path.constant';
+import { getCardCount } from '@/apis/card-interaction';
+import { createClient } from '@/utils/supabase/client';
 import Link from 'next/link';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Icon } from '@iconify/react';
+import sweetAlertUtil from '@/utils/common/sweet-alert-util';
 
 const CreateNewCard = () => {
+  const [isDisabled, setIsDisabled] = useState<boolean>(false);
+
+  /**
+   * 컴포넌트 마운트 시 한 번 실행:
+   * Supabase로부터 현재 로그인한 사용자를 조회하고,
+   * getCardCount 호출하여 사용자가 생성한 명함 개수를 가져옴
+   * 개수가 3개 이상이면 버튼을 비활성화 상태로 설정
+   */
+  useEffect(() => {
+    const checkCardCount = async () => {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (user) {
+        try {
+          const count = await getCardCount(user.id);
+          setIsDisabled(count >= 3);
+        } catch (error: any) {
+          console.error('명함 개수 조회 중 오류 발생 : ', error);
+        }
+      }
+    };
+
+    checkCardCount();
+  }, []);
+
+  /**
+   * 버튼 클릭 핸들러
+   * isDisabled가 true인 경우 링크 이동을 막고
+   * SweetAlert로 제한 메시지 표시
+   */
+  const handleClick = (e: React.MouseEvent) => {
+    if (isDisabled) {
+      e.preventDefault();
+      sweetAlertUtil.error(
+        '명함 생성 제한',
+        '최대 3개의 명함만 생성할 수 있습니다.'
+      );
+    }
+  };
+
   return (
     <Link
       href={ROUTES.EDITOR}
-      className='flex aspect-[9/5] w-[220px] cursor-pointer items-center justify-center rounded-xl border border-dashed border-gray-40 transition-colors hover:bg-gray-10'
+      onClick={handleClick}
+      className={`flex aspect-[9/5] w-[220px] cursor-pointer items-center justify-center rounded-xl border border-dashed border-gray-40 transition-colors ${
+        isDisabled
+          ? 'cursor-not-allowed opacity-50' // 활성화 스타일
+          : 'hover:bg-gray-10' // 활성화 hover
+      }`}
     >
       <div className='flex flex-col items-center justify-center text-extra-medium text-gray-40'>
         <Icon icon='mdi:add' width='26' height='26' />

--- a/src/components/editor/editor-ui/topbar/editor-topbar.tsx
+++ b/src/components/editor/editor-ui/topbar/editor-topbar.tsx
@@ -13,6 +13,7 @@ import sweetAlertUtil from '@/utils/common/sweet-alert-util';
 import { handleSwitchCard } from '@/utils/editor/warn-sweet-alert';
 import { createClient } from '@/utils/supabase/client';
 import { v4 } from 'uuid';
+import { getCardCount } from '@/apis/card-interaction';
 
 const EditorTopbar = () => {
   const undo = useEditorStore((state) => state.undo);
@@ -52,6 +53,16 @@ const EditorTopbar = () => {
 
     if (!user) {
       alert('로그인이 필요합니다.');
+      return;
+    }
+
+    // 명함 개수 확인, 3개 이상이면 생성 제한
+    const cardCount = await getCardCount(user.id);
+    if (cardCount >= 3) {
+      sweetAlertUtil.error(
+        '명함 생성 제한',
+        '최대 3개의 명함만 생성할 수 있습니다.'
+      );
       return;
     }
 

--- a/src/components/editor/editor-ui/topbar/editor-topbar.tsx
+++ b/src/components/editor/editor-ui/topbar/editor-topbar.tsx
@@ -57,11 +57,19 @@ const EditorTopbar = () => {
     }
 
     // 명함 개수 확인, 3개 이상이면 생성 제한
-    const cardCount = await getCardCount(user.id);
-    if (cardCount >= 3) {
+    try {
+      const cardCount = await getCardCount(user.id);
+      if (cardCount >= 3) {
+        sweetAlertUtil.error(
+          '명함 생성 제한',
+          '최대 3개의 명함만 생성할 수 있습니다.'
+        );
+        return;
+      }
+    } catch (error: any) {
       sweetAlertUtil.error(
-        '명함 생성 제한',
-        '최대 3개의 명함만 생성할 수 있습니다.'
+        '오류 발생',
+        error.message || '명함 개수를 확인하는 중 오류가 발생했습니다.'
       );
       return;
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #195 

<br>

## 📝 작업 내용

- 사용자의 명함이 3개 이상이면 생성 제한하는 로직을 추가하였습니다.

<br>

## 🖼 스크린샷

https://github.com/user-attachments/assets/09412566-2cc9-4865-a300-c69d3043bcfe

https://github.com/user-attachments/assets/89e0eb23-50b7-46b0-8f23-cc3604f5a7e1

<br>

## 💬 리뷰 요구사항

> 계정 있다면 테스트도 부탁드립니다~!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 최대 3개의 명함만 생성할 수 있도록 제한이 추가되었습니다.
  - 명함 생성 버튼이 3개 이상일 경우 비활성화되고, 초과 시 안내 메시지가 표시됩니다.
  - 에디터에서 저장 시에도 명함 개수 제한이 적용되어 초과 시 저장이 차단되고 경고 메시지가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->