### PR TITLE
[BUGFIX] #221 회원가입 창에서만 유효성 검사 나오도록 수정

### DIFF
--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -211,33 +211,37 @@ const AuthForm = ({ type }: AuthProps) => {
           className='flex h-11 w-[308px] items-center justify-between rounded-[6px] border border-gray-10 px-5 py-3'
         />
         <div className='g-1 flex items-center self-stretch'>
-          {formState.errors.email ? (
+          {type === 'signup' && (
             <>
-              <AuthErrorIcon />
-              <p className='text-caption-medium text-error'>
-                {formState.errors.email.message}
-              </p>
+              {formState.errors.email ? (
+                <>
+                  <AuthErrorIcon />
+                  <p className='text-caption-medium text-error'>
+                    {formState.errors.email.message}
+                  </p>
+                </>
+              ) : validationState.email.checked ? (
+                <>
+                  {validationState.email.duplicated ? (
+                    <AuthErrorIcon />
+                  ) : (
+                    <AuthConfirmIcon />
+                  )}
+                  <p
+                    className={`text-caption-medium ${
+                      validationState.email.duplicated
+                        ? 'text-error'
+                        : 'text-primary-40'
+                    }`}
+                  >
+                    {validationState.email.duplicated
+                      ? VALIDATE.DUPLICATED_EMAIL
+                      : VALIDATE.VALID_EMAIL}
+                  </p>
+                </>
+              ) : null}
             </>
-          ) : validationState.email.checked ? (
-            <>
-              {validationState.email.duplicated ? (
-                <AuthErrorIcon />
-              ) : (
-                <AuthConfirmIcon />
-              )}
-              <p
-                className={`text-caption-medium ${
-                  validationState.email.duplicated
-                    ? 'text-error'
-                    : 'text-primary-40'
-                }`}
-              >
-                {validationState.email.duplicated
-                  ? VALIDATE.DUPLICATED_EMAIL
-                  : VALIDATE.VALID_EMAIL}
-              </p>
-            </>
-          ) : null}
+          )}
         </div>
       </div>
 
@@ -252,7 +256,7 @@ const AuthForm = ({ type }: AuthProps) => {
           className='flex h-11 w-[308px] items-center justify-between rounded-[6px] border border-gray-10 px-5 py-3'
         />
         <div className='g-1 flex items-center self-stretch'>
-          {formState.errors.password && (
+          {type === 'signup' && formState.errors.password && (
             <>
               <AuthErrorIcon />
               <p className='text-caption-medium text-error'>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #221 

<br>

## 📝 작업 내용

- 회원가입 창에서만 유효성 검사 나오도록 수정
- type === "signup" 추가

<br>

## 🖼 스크린샷

![image](https://github.com/user-attachments/assets/edccd2cd-6f01-41e7-962f-070e88361793)
![image](https://github.com/user-attachments/assets/895fb33b-0794-473f-841b-6633cc94dce6)


<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이메일 및 비밀번호 오류/유효성 메시지가 이제 회원가입(가입) 시에만 표시되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->