### PR TITLE
[FEAT] #235 작업 내용 sessionStorage에 저장

### DIFF
--- a/src/store/editor.store.ts
+++ b/src/store/editor.store.ts
@@ -2,6 +2,7 @@ import { CanvasElements } from '@/types/editor.type';
 import { Templates } from '@/types/supabase.type';
 import { getCanvasKeys } from '@/utils/editor/editor-getCanvasKeys.util';
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 /**
  * 에디터 전체 인터페이스
@@ -70,191 +71,214 @@ export interface EditorState {
   setTemplate: (_element: Templates) => void;
 }
 
-export const useEditorStore = create<EditorState>((set, get) => ({
-  template: null,
+export const useEditorStore = create<EditorState>()(
+  persist(
+    (set, get) => ({
+      template: null,
 
-  canvasElements: [],
-  histories: [[]],
-  historyIdx: 0,
-
-  canvasBackElements: [],
-  backHistories: [[]],
-  backHistoryIdx: 0,
-
-  selectedElementId: null,
-  editingElementId: null,
-  selectedElementType: null,
-  toolbar: null,
-
-  //배경
-  backgroundColor: null,
-  backgroundColorBack: null,
-  backgroundImage: null,
-
-  isCanvasFront: true,
-
-  title: '',
-
-  slug: null,
-
-  setTitle: (title) => set({ title }),
-  setSelectedElementId: (id) => set({ selectedElementId: id }),
-  setEditingElementId: (id) => set({ editingElementId: id }),
-  setSelectedElementType: (type) => set({ selectedElementType: type }),
-  setToolbar: (toolbar) => set({ toolbar }),
-  setCanvasFront: (status) => set({ isCanvasFront: status }),
-
-  //배경
-  setBackgroundColor: (color) => set({ backgroundColor: color }),
-  setBackgroundColorBack: (color) => set({ backgroundColorBack: color }),
-  setSlug: (slug) => set({ slug }),
-
-  addElement: (element) => {
-    const state = get();
-    const {
-      elementsKey,
-      historiesKey,
-      historyIdxKey,
-      currentElements,
-      currentHistories,
-      currentHistoryIdx,
-    } = getCanvasKeys(state);
-
-    const newElements = [...currentElements, element];
-    const newHistories = [
-      ...currentHistories.slice(0, currentHistoryIdx + 1),
-      newElements,
-    ];
-
-    set({
-      [elementsKey]: newElements,
-      [historiesKey]: newHistories,
-      [historyIdxKey]: newHistories.length - 1,
-    });
-  },
-
-  updateElement: (id: string, updates: Partial<CanvasElements>) => {
-    const state = get();
-    const {
-      elementsKey,
-      historiesKey,
-      historyIdxKey,
-      currentElements,
-      currentHistories,
-      currentHistoryIdx,
-    } = getCanvasKeys(state);
-
-    const updateElement = currentElements.map((el) =>
-      el.id === id ? ({ ...el, ...updates } as CanvasElements) : el
-    );
-
-    const newHistories = [
-      ...currentHistories.slice(0, currentHistoryIdx + 1),
-      updateElement,
-    ];
-
-    set({
-      [elementsKey]: updateElement,
-      [historiesKey]: newHistories,
-      [historyIdxKey]: newHistories.length - 1,
-    });
-  },
-
-  removeElement: (id) => {
-    const state = get();
-    const {
-      elementsKey,
-      historiesKey,
-      historyIdxKey,
-      currentElements,
-      currentHistories,
-      currentHistoryIdx,
-    } = getCanvasKeys(state);
-
-    const removeElement = currentElements.filter((el) => el.id !== id);
-    const newHistories = [
-      ...currentHistories.slice(0, currentHistoryIdx + 1),
-      removeElement,
-    ];
-
-    set({
-      [elementsKey]: removeElement,
-      [historiesKey]: newHistories,
-      [historyIdxKey]: newHistories.length - 1,
-    });
-  },
-
-  reset: () => {
-    set({
       canvasElements: [],
-      canvasBackElements: [],
       histories: [[]],
       historyIdx: 0,
+
+      canvasBackElements: [],
       backHistories: [[]],
       backHistoryIdx: 0,
+
       selectedElementId: null,
       editingElementId: null,
       selectedElementType: null,
-      title: '',
+      toolbar: null,
+
+      //배경
       backgroundColor: null,
       backgroundColorBack: null,
-    });
-  },
+      backgroundImage: null,
 
-  undo: () => {
-    const state = get();
-    const { elementsKey, historyIdxKey, currentHistories, currentHistoryIdx } =
-      getCanvasKeys(state);
+      isCanvasFront: true,
 
-    if (currentHistoryIdx > 0) {
-      const undoHistoryIdx = currentHistoryIdx - 1;
-      const undoElement = currentHistories[undoHistoryIdx];
-      set({
-        [elementsKey]: undoElement,
-        [historyIdxKey]: undoHistoryIdx,
-        selectedElementId: null,
-        editingElementId: null,
-        selectedElementType: null,
-      });
+      title: '',
+
+      slug: null,
+
+      setTitle: (title) => set({ title }),
+      setSelectedElementId: (id) => set({ selectedElementId: id }),
+      setEditingElementId: (id) => set({ editingElementId: id }),
+      setSelectedElementType: (type) => set({ selectedElementType: type }),
+      setToolbar: (toolbar) => set({ toolbar }),
+      setCanvasFront: (status) => set({ isCanvasFront: status }),
+
+      //배경
+      setBackgroundColor: (color) => set({ backgroundColor: color }),
+      setBackgroundColorBack: (color) => set({ backgroundColorBack: color }),
+      setSlug: (slug) => set({ slug }),
+
+      addElement: (element) => {
+        const state = get();
+        const {
+          elementsKey,
+          historiesKey,
+          historyIdxKey,
+          currentElements,
+          currentHistories,
+          currentHistoryIdx,
+        } = getCanvasKeys(state);
+
+        const newElements = [...currentElements, element];
+        const newHistories = [
+          ...currentHistories.slice(0, currentHistoryIdx + 1),
+          newElements,
+        ];
+
+        set({
+          [elementsKey]: newElements,
+          [historiesKey]: newHistories,
+          [historyIdxKey]: newHistories.length - 1,
+        });
+      },
+
+      updateElement: (id: string, updates: Partial<CanvasElements>) => {
+        const state = get();
+        const {
+          elementsKey,
+          historiesKey,
+          historyIdxKey,
+          currentElements,
+          currentHistories,
+          currentHistoryIdx,
+        } = getCanvasKeys(state);
+
+        const updateElement = currentElements.map((el) =>
+          el.id === id ? ({ ...el, ...updates } as CanvasElements) : el
+        );
+
+        const newHistories = [
+          ...currentHistories.slice(0, currentHistoryIdx + 1),
+          updateElement,
+        ];
+
+        set({
+          [elementsKey]: updateElement,
+          [historiesKey]: newHistories,
+          [historyIdxKey]: newHistories.length - 1,
+        });
+      },
+
+      removeElement: (id) => {
+        const state = get();
+        const {
+          elementsKey,
+          historiesKey,
+          historyIdxKey,
+          currentElements,
+          currentHistories,
+          currentHistoryIdx,
+        } = getCanvasKeys(state);
+
+        const removeElement = currentElements.filter((el) => el.id !== id);
+        const newHistories = [
+          ...currentHistories.slice(0, currentHistoryIdx + 1),
+          removeElement,
+        ];
+
+        set({
+          [elementsKey]: removeElement,
+          [historiesKey]: newHistories,
+          [historyIdxKey]: newHistories.length - 1,
+        });
+      },
+
+      reset: () => {
+        set({
+          canvasElements: [],
+          canvasBackElements: [],
+          histories: [[]],
+          historyIdx: 0,
+          backHistories: [[]],
+          backHistoryIdx: 0,
+          selectedElementId: null,
+          editingElementId: null,
+          selectedElementType: null,
+          title: '',
+          backgroundColor: null,
+          backgroundColorBack: null,
+        });
+      },
+
+      undo: () => {
+        const state = get();
+        const {
+          elementsKey,
+          historyIdxKey,
+          currentHistories,
+          currentHistoryIdx,
+        } = getCanvasKeys(state);
+
+        if (currentHistoryIdx > 0) {
+          const undoHistoryIdx = currentHistoryIdx - 1;
+          const undoElement = currentHistories[undoHistoryIdx];
+          set({
+            [elementsKey]: undoElement,
+            [historyIdxKey]: undoHistoryIdx,
+            selectedElementId: null,
+            editingElementId: null,
+            selectedElementType: null,
+          });
+        }
+      },
+
+      redo: () => {
+        const state = get();
+        const {
+          elementsKey,
+          historyIdxKey,
+          currentHistories,
+          currentHistoryIdx,
+        } = getCanvasKeys(state);
+        if (currentHistoryIdx < currentHistories.length - 1) {
+          const redoHistoryIdx = currentHistoryIdx + 1;
+          const redoElement = currentHistories[redoHistoryIdx];
+          set({
+            [elementsKey]: redoElement,
+            [historyIdxKey]: redoHistoryIdx,
+            selectedElementId: null,
+            editingElementId: null,
+            selectedElementType: null,
+          });
+        }
+      },
+
+      setCanvasElements: (elements) => {
+        const newHistories = [[...elements]];
+        set({
+          canvasElements: elements,
+          histories: newHistories,
+          historyIdx: 0,
+        });
+      },
+
+      setCanvasBackElements: (elements) => {
+        const newHistories = [[...elements]];
+        set({
+          canvasBackElements: elements,
+          backHistories: newHistories,
+          backHistoryIdx: 0,
+        });
+      },
+
+      setTemplate: (element) => {
+        set({ template: element });
+      },
+    }),
+    {
+      name: 'editor-storage',
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (state) => ({
+        canvasElements: state.canvasElements,
+        canvasBackElements: state.canvasBackElements,
+        backgroundColor: state.backgroundColor,
+        backgroundColorBack: state.backgroundColorBack,
+        title: state.title,
+      }),
     }
-  },
-
-  redo: () => {
-    const state = get();
-    const { elementsKey, historyIdxKey, currentHistories, currentHistoryIdx } =
-      getCanvasKeys(state);
-    if (currentHistoryIdx < currentHistories.length - 1) {
-      const redoHistoryIdx = currentHistoryIdx + 1;
-      const redoElement = currentHistories[redoHistoryIdx];
-      set({
-        [elementsKey]: redoElement,
-        [historyIdxKey]: redoHistoryIdx,
-        selectedElementId: null,
-        editingElementId: null,
-        selectedElementType: null,
-      });
-    }
-  },
-
-  setCanvasElements: (elements) => {
-    const newHistories = [[...elements]];
-    set({
-      canvasElements: elements,
-      histories: newHistories,
-      historyIdx: 0,
-    });
-  },
-
-  setCanvasBackElements: (elements) => {
-    const newHistories = [[...elements]];
-    set({
-      canvasBackElements: elements,
-      backHistories: newHistories,
-      backHistoryIdx: 0,
-    });
-  },
-
-  setTemplate: (element) => {
-    set({ template: element });
-  },
-}));
+  )
+);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #235 

<br>

## 📝 작업 내용

- persist 추가
- sessionStorage에 canvasElements, canvasBackElements, backgroundColor, backgroundColorBack 저장




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 에디터 상태가 세션 저장소에 자동으로 저장되어, 페이지를 새로고침해도 최근 작업 내용이 유지됩니다. (저장되는 항목: 캔버스 요소, 배경색, 제목 등)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->