### PR TITLE
[BUGFIX] #249 닉네임 중복 시 회원가입 가능한 버그 수정

### DIFF
--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -140,7 +140,7 @@ const AuthForm = ({ type }: AuthProps) => {
 
   // 디바운스로 중복 검사
   const debouncedCheck = useMemo(() => {
-    return debounce(handleDuplicate, 500);
+    return debounce(handleDuplicate, 400);
   }, []);
 
   // 이메일 호출
@@ -304,7 +304,11 @@ const AuthForm = ({ type }: AuthProps) => {
         <button
           className='flex h-11 cursor-pointer items-center justify-center gap-1 self-stretch rounded-[6px] bg-primary-40 px-3 py-[6px] hover:bg-primary-50'
           type='submit'
-          disabled={!formState.isValid || validationState.email.duplicated}
+          disabled={
+            !formState.isValid ||
+            validationState.email.duplicated ||
+            validationState.nickName.duplicated
+          }
         >
           <p className='text-label2-medium text-white'>회원가입</p>
         </button>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #249 
- 
<br>

## 📝 작업 내용

- 회원가입 버튼에 닉네임 중복시 비활성화 추가
- 중복 검사 디바운싱 0.4 초로 수정

<br>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 닉네임 중복 확인의 딜레이가 500ms에서 400ms로 단축되었습니다.
  - 회원가입 폼에서 닉네임이 중복될 경우 제출 버튼이 비활성화되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->