### PR TITLE
[FEAT]#234 저장 및 공유 모달 기존 로직 변경 및 공통 모달 수정

### DIFF
--- a/src/app/dashboard/my-cards/page.tsx
+++ b/src/app/dashboard/my-cards/page.tsx
@@ -1,3 +1,4 @@
+import SaveShareModal from '@/components/card/save-share-modal';
 import CardList from '@/components/dashboard/card-list';
 import MonthlyChart from '@/components/dashboard/monthly-chart';
 import MostViewCard from '@/components/dashboard/most-view-card';
@@ -43,6 +44,9 @@ const MyCardsPage = async () => {
       <article className='mt-[14px] rounded-xl bg-white px-7 pb-8'>
         <CardList userId={userId} />
       </article>
+
+      {/* 저장 및 공유하기 모달 */}
+      <SaveShareModal />
     </>
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import AuthListener from '@/components/auth/auth-listener';
 import AuthModal from '@/components/modals/auth/auth-modal';
 import Header from '@/components/layouts/header';
 import KakaoScript from '@/components/card/kakao-script';
+import { CommonModal } from '@/components/common/common-modal';
 
 export const metadata: Metadata = {
   title: 'Uuno',
@@ -25,7 +26,7 @@ export default function RootLayout({
           <AuthListener />
           <Header />
           <AuthModal />
-
+          <CommonModal />
           <main className='mt-16'>{children}</main>
         </Providers>
       </body>

--- a/src/components/card-detail/left-nav-section.tsx
+++ b/src/components/card-detail/left-nav-section.tsx
@@ -5,7 +5,6 @@ import CardSelector from '@/components/card-detail/card-selector';
 import Link from 'next/link';
 import customSweetAlert from '@/utils/card-detail/custom-sweet-alert';
 import sweetAlertUtil from '@/utils/common/sweet-alert-util';
-import { useCommonModalStore } from '@/store/common-modal.store';
 import SaveShareModal from '@/components/card/save-share-modal';
 import useCardSelectList from '@/hooks/queries/use-card-select-list';
 import { authStore } from '@/store/auth.store';
@@ -14,9 +13,10 @@ import SkeletonUI from '@/components/card-detail/left-nav-skeleton-ui';
 import { useEffect, useState } from 'react';
 import { useMyCardDelete } from '@/hooks/mutations/use-mycard-delete';
 import { useSlugUrl } from '@/hooks/queries/use-slug-url';
+import { useSaveShareModalStore } from '@/store/save-share-modal.store';
 
 const LeftNavSection = () => {
-  const open = useCommonModalStore((state) => state.open);
+  const openShareModal = useSaveShareModalStore((state) => state.open);
   const nickName = authStore((state) => state.userName);
   const pathname = usePathname();
   const cardId = pathname.split('/')[2] || '';
@@ -70,6 +70,23 @@ const LeftNavSection = () => {
     isPending: isPendingUrl,
   } = useSlugUrl(slug ?? '');
 
+  const handleOpenShareModal = () => {
+    if (slug && slugToUrl) {
+      openShareModal({
+        cardId: cardId,
+        linkUrl: `${origin}/${slug}?source=direct`,
+        title: `${nickName}의 명함`,
+        imageUrl: slugToUrl ?? '',
+        description: 'Uuno에서 생성한 명함',
+      });
+    } else {
+      sweetAlertUtil.error(
+        '공유 불가',
+        '명함 정보를 불러오는 것에 실패했습니다. 잠시 후 다시 시도해주세요.'
+      );
+    }
+  };
+
   if (isError || getSlugError || getUrlError) {
     return <div>에러가 발생했습니다.</div>;
   }
@@ -91,7 +108,7 @@ const LeftNavSection = () => {
             편집하기
           </Link>
           <button
-            onClick={open}
+            onClick={handleOpenShareModal}
             className='mx-2 flex w-full justify-center rounded-full bg-gray-5 px-3 py-[10px] text-label2-regular'
           >
             저장 및 공유하기
@@ -123,13 +140,7 @@ const LeftNavSection = () => {
           </button>
         </div>
       </div>
-      <SaveShareModal
-        cardId={cardId}
-        linkUrl={`${origin}/${slug}`}
-        title={`${nickName}의 명함`}
-        imageUrl={slugToUrl ?? ''}
-        description='Uuno에서 생성한 명함'
-      />
+      <SaveShareModal />
     </>
   );
 };

--- a/src/components/card/save-share-modal.tsx
+++ b/src/components/card/save-share-modal.tsx
@@ -159,7 +159,7 @@ const SaveShareModal = () => {
         close();
       }
     };
-  }, [isOpen, cardId, openCommonModal, closeCommonModal, close]);
+  }, [isOpen, cardId, slug, openCommonModal, closeCommonModal, close]);
 
   // dummy data 파일명
   const downloadCardImageMutation = useDownloadCardImageMutation(

--- a/src/components/common/common-modal.tsx
+++ b/src/components/common/common-modal.tsx
@@ -10,31 +10,27 @@ import {
 } from '@/components/ui/dialog';
 import { useCommonModalStore } from '@/store/common-modal.store';
 import clsx from 'clsx';
-import { ReactNode } from 'react';
 
-interface CommonModalProps {
-  title: string;
-  description?: string;
-  ctnClassName?: string;
-  children: ReactNode;
-  footer?: ReactNode;
-  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
-}
+export function CommonModal() {
+  const {
+    isOpen,
+    title,
+    description,
+    content,
+    footer,
+    maxWidth,
+    ctnClassName,
+    close,
+    onClose,
+  } = useCommonModalStore();
 
-export function CommonModal({
-  title,
-  description,
-  ctnClassName,
-  children,
-  footer,
-  maxWidth,
-}: CommonModalProps) {
-  const isOpen = useCommonModalStore((state) => state.isOpen);
-  const close = useCommonModalStore((state) => state.close);
   const handleOpenChange = (open: boolean) => {
-    if (!open) {
-      close();
-    }
+if (!open) {
+  if (onClose) {
+    onClose(); // 사용자 정의 onClose 호출
+  }
+  close();
+}
   };
 
   const maxWidthStyle = {
@@ -56,7 +52,7 @@ export function CommonModal({
           <DialogTitle className='text-heading-semi'>{title}</DialogTitle>
           {description && <DialogDescription>{description}</DialogDescription>}
         </DialogHeader>
-        <div className='py-4'>{children}</div>
+        <div className='py-4'>{content}</div>
         {footer && <DialogFooter>{footer}</DialogFooter>}
       </DialogContent>
     </Dialog>

--- a/src/components/dashboard/card-edit-dropdown.tsx
+++ b/src/components/dashboard/card-edit-dropdown.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -21,6 +21,8 @@ import customSweetAlert from '@/utils/card-detail/custom-sweet-alert';
 import { deleteCard } from '@/apis/card-delete';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMyCardDelete } from '@/hooks/mutations/use-mycard-delete';
+import { useSaveShareModalStore } from '@/store/save-share-modal.store';
+import { authStore } from '@/store/auth.store';
 
 interface Props {
   cardId: string;
@@ -29,6 +31,7 @@ interface Props {
   dateLabel: string;
   onEdit: () => void;
   slug: string;
+  imageUrl: string;
 }
 
 const CardEditDropdown = ({
@@ -38,13 +41,32 @@ const CardEditDropdown = ({
   dateLabel,
   onEdit,
   slug,
+  imageUrl,
 }: Props) => {
   // 드롭다운 상태 관리 추가
   const [open, setOpen] = useState(false);
   // 삭제 중 상태 관리 추가
   const [isDeleting, setIsDeleting] = useState(false);
 
-  const openModal = useCommonModalStore((state) => state.open);
+  const [origin, setOrigin] = useState<string>('');
+  useEffect(() => {
+    if (typeof window !== 'undefined') setOrigin(window.location.origin);
+  }, []);
+
+  const nickName = authStore((state) => state.userName);
+
+  const openShareModal = useSaveShareModalStore((state) => state.open);
+  const handleOpenShareModal = () => {
+    if (slug) {
+      openShareModal({
+        cardId,
+        linkUrl: `${origin}/${slug}?source=direct`,
+        title: `${nickName}의 명함`,
+        imageUrl,
+        description: 'Uuno에서 생성한 명함',
+      });
+    }
+  };
 
   const { mutate: deleteMutate } = useMyCardDelete({ slug, cardId, userId });
 
@@ -132,7 +154,7 @@ const CardEditDropdown = ({
 
           {/* 공유하기 모달 */}
           {/* TODO: 공유하기 모달이 잘 열리지만 배경이 보이지 않고 완전 까맣게 됨. 확인 및 수정필요 */}
-          <DropdownMenuItem onClick={openModal}>
+          <DropdownMenuItem onClick={handleOpenShareModal}>
             <Icon icon='tdesign:save' width='16' height='16' />
             저장 및 공유하기
           </DropdownMenuItem>

--- a/src/components/dashboard/card-edit-dropdown.tsx
+++ b/src/components/dashboard/card-edit-dropdown.tsx
@@ -153,7 +153,6 @@ const CardEditDropdown = ({
           {/* 드롭다운 목록 */}
 
           {/* 공유하기 모달 */}
-          {/* TODO: 공유하기 모달이 잘 열리지만 배경이 보이지 않고 완전 까맣게 됨. 확인 및 수정필요 */}
           <DropdownMenuItem onClick={handleOpenShareModal}>
             <Icon icon='tdesign:save' width='16' height='16' />
             저장 및 공유하기

--- a/src/components/dashboard/card-item.tsx
+++ b/src/components/dashboard/card-item.tsx
@@ -68,6 +68,7 @@ const CardItem = ({ card }: CardItemProps) => {
           dateLabel={dateLabelText}
           onEdit={() => setIsEditing(true)}
           slug={card.slug}
+          imageUrl={card.frontImgURL || ''}
         />
 
         <Link href={`${ROUTES.MYCARD}/${card.id}`} className='h-[122px]'>
@@ -107,13 +108,7 @@ const CardItem = ({ card }: CardItemProps) => {
       <div className='p-1 text-caption-medium text-gray-70'>
         {dateLabelText}
       </div>
-      <SaveShareModal
-        cardId={card.id}
-        linkUrl={`${origin}/${card.slug}`}
-        title={`${nickName}의 명함`}
-        imageUrl={slugToUrl ?? ''}
-        description='Uuno에서 생성한 명함'
-      />
+      <SaveShareModal />
     </div>
   );
 };

--- a/src/store/common-modal.store.ts
+++ b/src/store/common-modal.store.ts
@@ -1,13 +1,49 @@
 import { create } from 'zustand';
+import { ReactNode } from 'react';
 
-interface ModalState {
+interface CommonModalState {
   isOpen: boolean;
-  open: () => void;
+  title: string;
+  description?: string;
+  content: ReactNode | null;
+  footer?: ReactNode;
+  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
+  ctnClassName?: string;
+  onClose?: () => void;
+
+  open: (params: {
+    title: string;
+    description?: string;
+    content: ReactNode;
+    footer?: ReactNode;
+    maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
+    ctnClassName?: string;
+    onClose?: () => void;
+  }) => void;
   close: () => void;
 }
 
-export const useCommonModalStore = create<ModalState>((set) => ({
+export const useCommonModalStore = create<CommonModalState>((set) => ({
   isOpen: false,
-  open: () => set({ isOpen: true }),
+  title: '',
+  description: undefined,
+  content: null,
+  footer: undefined,
+  maxWidth: 'md',
+  ctnClassName: '',
+  onClose: undefined,
+
+  open: (params) =>
+    set({
+      isOpen: true,
+      title: params.title,
+      description: params.description,
+      content: params.content,
+      footer: params.footer,
+      maxWidth: params.maxWidth,
+      ctnClassName: params.ctnClassName,
+      onClose: params.onClose,
+    }),
+
   close: () => set({ isOpen: false }),
 }));

--- a/src/store/save-share-modal.store.ts
+++ b/src/store/save-share-modal.store.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+
+interface SaveShareModalState {
+  isOpen: boolean;
+  cardId: string;
+  title: string;
+  description: string;
+  imageUrl: string;
+  linkUrl: string;
+
+  open: (params: {
+    cardId: string;
+    title: string;
+    description: string;
+    imageUrl: string;
+    linkUrl: string;
+  }) => void;
+  close: () => void;
+}
+
+export const useSaveShareModalStore = create<SaveShareModalState>((set) => ({
+  isOpen: false,
+  cardId: '',
+  title: '',
+  description: '',
+  imageUrl: '',
+  linkUrl: '',
+
+  open: (params) =>
+    set({
+      isOpen: true,
+      cardId: params.cardId,
+      title: params.title,
+      description: params.description,
+      imageUrl: params.imageUrl,
+      linkUrl: params.linkUrl,
+    }),
+
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #234

<br>

## 📝 작업 내용

- 저장 및 공유 모달 기존 로직 변경 (전역상태 관리)
- 공통 모달 수정

<br>

## 🖼 스크린샷


https://github.com/user-attachments/assets/93848d16-8f32-454e-92fa-6ed6505dfbae


<br>

## 💬 리뷰 요구사항

> 없습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 대시보드 및 카드 상세 페이지에 저장 및 공유 모달 기능이 추가되었습니다.
  - 공통 모달 시스템이 도입되어 다양한 모달을 통합적으로 관리할 수 있습니다.

- **버그 수정**
  - 필수 데이터가 없을 경우 공유 모달이 열리지 않도록 오류 처리가 추가되었습니다.

- **리팩터링**
  - 저장 및 공유 모달과 공통 모달의 구조가 개선되어 더 유연하게 동작합니다.
  - 모달 관련 상태 관리가 개선되었습니다.

- **기타**
  - 일부 컴포넌트의 prop 구조가 변경되어 이미지 URL 등 추가 정보 전달이 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->