### PR TITLE
[BUG FIX] #255 내명함페이지 가장 높은 조회수 

### DIFF
--- a/src/components/dashboard/monthly-chart.tsx
+++ b/src/components/dashboard/monthly-chart.tsx
@@ -67,14 +67,14 @@ const MonthlyChart = ({ userId }: MonthlyChartProps) => {
 
   //라인 차트 데이터 분해
   const {
-    monthDates = [],
-    monthViewCnt = [],
-    monthSaveCnt = [],
-    start = '',
-  } = lineData || {};
+    monthDates,
+    monthViewCnt,
+    monthSaveCnt,
+    start,
+  } = lineData;
 
   // 총 통계 데이터 분해
-  const { totalMonthViews = 0, totalMonthSaves = 0 } = statsData || {};
+  const { totalMonthViews = 0, totalMonthSaves = 0 } = statsData;
 
   // 차트에 표시할 "YYYY.MM"
   const yearMonth = formatYearMonthString(start);

--- a/src/components/dashboard/most-view-card.tsx
+++ b/src/components/dashboard/most-view-card.tsx
@@ -15,10 +15,9 @@ const MostViewCard = ({ userId }: MostViewedCardProps) => {
 
   if (isPending)
     return (
-      <div className='p4 rounded-xl bg-white'>
-        <div className='mb-4 h-6 w-1/3 animate-pulse rounded bg-gray-10'>
-          <div className='h-32 animate-pulse rounded bg-gray-5' />
-        </div>
+      <div className='rounded-xl bg-white p-4'>
+        <div className='mb-4 h-6 w-1/3 animate-pulse rounded bg-gray-10' />
+        <div className='h-[120px] w-full animate-pulse rounded bg-gray-5' />
       </div>
     );
 
@@ -29,14 +28,12 @@ const MostViewCard = ({ userId }: MostViewedCardProps) => {
         <p className='text-label2-regular'>{error.message}</p>
       </div>
     );
-  if (!data)
-    return (
-      <div className='mb-6 rounded-xl bg-red-50 p-4 text-primary-60'>
-        <p>명함이 존재하지 않습니다. 명함을 만들어주세요.</p>
-      </div>
-    );
 
-  const { title, id: cardId } = data;
+  // 유효 데이터 확인
+  const hasData = !!data && data.totalMonthViews > 0;
+  const titleText = hasData ? data?.title : '-';
+  const cardLink = hasData ? `${ROUTES.MYCARD}/${data.id}` : '#';
+  const cardId = data?.id;
 
   return (
     <div className='rounded-xl bg-white p-[14px]'>
@@ -44,12 +41,12 @@ const MostViewCard = ({ userId }: MostViewedCardProps) => {
         <p className='text-label2-medium text-gray-70'>
           가장 조회 수가 높은 명함
         </p>
-        <Link href={`${ROUTES.MYCARD}/${cardId}`}>
+        <Link href={cardLink}>
           <Icon icon='tdesign:arrow-right' width='20' height='20' />
         </Link>
       </div>
-      <Link href={`${ROUTES.MYCARD}/${cardId}`}>
-        <h3 className='text-label1-semi text-black'>{title}</h3>
+      <Link href={cardLink}>
+        <h3 className='text-label1-semi text-black'>{titleText}</h3>
       </Link>
       <div className='flex flex-col justify-end'>
         <div className='relative mt-[13px] h-[88px] w-[226px]'>

--- a/src/hooks/mutations/use-mycard-delete.ts
+++ b/src/hooks/mutations/use-mycard-delete.ts
@@ -15,8 +15,18 @@ export const useMyCardDelete = ({ cardId, slug, userId }: Props) => {
     mutationFn: () => deleteCard({ cardId, slug, userId }),
     onSuccess: () => {
       queryClient.invalidateQueries({
+        // 명함 목록 다시 가져오기
         queryKey: [QUERY_KEY.CARD_LIST, userId],
-      });
+      }),
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEY.MOST_VIEW, userId],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEY.MONTH_CHART, userId],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEY.MONTH_STATS, userId],
+        });
     },
     onError: (error) => {
       console.error('카드 삭제 중 오류 발생 : ', error);

--- a/src/hooks/queries/use-card-list.ts
+++ b/src/hooks/queries/use-card-list.ts
@@ -6,8 +6,6 @@ const useCardList = (userId: string) => {
   return useQuery({
     queryKey: [QUERY_KEY.CARD_LIST, userId],
     queryFn: () => getCardList(userId),
-    staleTime: 0,
-    refetchOnWindowFocus: true, // 창이 포커스될 때마다 재요청
     refetchOnMount: 'always',
   });
 };

--- a/src/hooks/queries/use-month-chart.ts
+++ b/src/hooks/queries/use-month-chart.ts
@@ -29,6 +29,7 @@ export const useMostViewedCard = (userId: string) => {
   return useQuery({
     queryKey: [QUERY_KEY.MOST_VIEW, userId],
     queryFn: () => getMostViewedCard(userId),
+    refetchOnMount: 'always',
     enabled: !!userId,
   });
 };

--- a/src/hooks/queries/use-month-chart.ts
+++ b/src/hooks/queries/use-month-chart.ts
@@ -11,6 +11,7 @@ export const useUserMonthLineData = (userId: string) => {
   return useQuery({
     queryKey: [QUERY_KEY.MONTH_CHART, userId],
     queryFn: () => getUserMonthlyLineData(userId),
+    refetchOnMount: 'always',
     enabled: !!userId,
   });
 };
@@ -20,6 +21,7 @@ export const useUserMonthStats = (userId: string) => {
   return useQuery({
     queryKey: [QUERY_KEY.MONTH_STATS, userId],
     queryFn: () => getUserMonthlyStats(userId),
+    refetchOnMount: 'always',
     enabled: !!userId,
   });
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #255 

<br>

## 📝 작업 내용

- 명함 생성 및 삭제시 관련 값들이 항상 새로고침 되도록 수정
- 명함이 없을 시에 기본 차트가 보여지도록 수정

<br>

## 🖼 스크린샷

삭제시

https://github.com/user-attachments/assets/cfce3254-4c4c-405b-a7d9-1be4a6f865cf

차트 업데이트 반영

https://github.com/user-attachments/assets/205de408-7ee4-4bd6-bcad-904c46f4df8b

카드 생성 및 조회수 자료가 없을때 명함 이름이 표기되지않습니다.

https://github.com/user-attachments/assets/a44289b1-8c66-440b-9dd7-6c717aada834


<br>

## 💬 리뷰 요구사항

> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 월간 차트와 최다 조회 카드 컴포넌트의 로딩 및 데이터 표시 방식이 개선되었습니다.
- **버그 수정**
  - 카드 삭제 시 월간 차트, 통계, 최다 조회 카드 등 관련 데이터가 즉시 갱신됩니다.
- **리팩터**
  - 월간 차트 및 통계 데이터 쿼리가 항상 최신 상태를 유지하도록 개선되었습니다.
- **문서화**
  - 월간 차트 관련 API 함수에 상세한 JSDoc 주석이 추가되어 명확성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->