### PR TITLE
[REFACTOR]#201 텍스트 편집시 엔터 없이도 저장 및 바깥 영역 클릭시 선택 해제

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -12,6 +12,15 @@ const EditPage = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const redo = useEditorStore((state) => state.redo);
   const undo = useEditorStore((state) => state.undo);
+  const setSelectedElementId = useEditorStore(
+    (state) => state.setSelectedElementId
+  );
+  const setEditingElementId = useEditorStore(
+    (state) => state.setEditingElementId
+  );
+  const setSelectedElementType = useEditorStore(
+    (state) => state.setSelectedElementType
+  );
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -45,7 +54,16 @@ const EditPage = () => {
       <EditorSideBar />
       <div ref={containerRef} className='flex flex-1 flex-col bg-gray-5'>
         <EditorTopbar />
-        <div className='flex h-full w-full items-center justify-center overflow-auto'>
+        <div
+          className='flex h-full w-full items-center justify-center overflow-auto'
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              setSelectedElementId(null);
+              setEditingElementId(null);
+              setSelectedElementType(null);
+            }
+          }}
+        >
           <EditorContainer />
         </div>
         <EditorBottomTab />

--- a/src/components/editor/editor-container.tsx
+++ b/src/components/editor/editor-container.tsx
@@ -163,7 +163,7 @@ const EditorContainer = () => {
         height={currentStageHeight}
         scale={{ x: zoom, y: zoom }}
         onWheel={handleWheel}
-        onMouseDown={(e) => {
+        onClick={(e) => {
           if (e.target === e.target.getStage()) {
             setSelectedElementId(null);
             setEditingElementId(null);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #201 

<br>

## 📝 작업 내용

-  텍스트 편집 시 엔터클릭 없이도 저장 
-  바깥영역 클릭시 선택 해제
-

<br>

## 🖼 스크린샷

이미지

<br>

## 💬 리뷰 요구사항

> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - 빈 편집기 영역을 클릭할 때 선택 및 편집 중인 요소가 해제되도록 동작이 개선되었습니다.
    - 일부 상호작용이 마우스 버튼 누름에서 클릭 이벤트로 변경되어 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->