### PR TITLE
[FEAT]#262 기능 활성화 이전 안내 문구 창 추가

### DIFF
--- a/src/app/[...slug]/page.client.tsx
+++ b/src/app/[...slug]/page.client.tsx
@@ -8,6 +8,7 @@ import {
 import { useIpAddressQuery } from '@/hooks/queries/use-ip-address';
 import { useInteractionTracker } from '@/hooks/use-interaction-tracker';
 import { Cards } from '@/types/supabase.type';
+import sweetAlertUtil from '@/utils/common/sweet-alert-util';
 import { useSearchParams } from 'next/navigation';
 
 interface SlugClientPageParams {
@@ -88,6 +89,10 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
     }
   };
 
+  const handleComingSoon = () => {
+    sweetAlertUtil.info('곧 만나요!', '해당 기능은 곧 업데이트될 예정입니다');
+  };
+
   // 페이지 타이틀 생성
   const pageTitle = `${initialData.users?.nick_name || ''}님의 ${initialData?.title || ''} 명함`;
 
@@ -109,7 +114,7 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
           이미지 저장
         </button>
         <button
-          onClick={handleSaveVCard}
+          onClick={handleComingSoon}
           className='flex h-[46px] items-center justify-center rounded-[46px] bg-primary-40 px-[46px] py-[6px] text-label2-medium text-white shadow-[0px_4px_40px_0px_rgba(0,0,0,0.15)]'
         >
           연락처 저장

--- a/src/components/card-detail/export-buttons.tsx
+++ b/src/components/card-detail/export-buttons.tsx
@@ -5,9 +5,13 @@ import CsvIcon from '@/components/icons/csv-icon';
 import PdfIcon from '@/components/icons/pdf-icon';
 import CsvDisableIcon from '@/components/icons/csv-disable-icon';
 import PdfDisableIcon from '@/components/icons/pdf-disable-icon';
+import sweetAlertUtil from '@/utils/common/sweet-alert-util';
 
 const ExportButtons = () => {
   const hasData = useCardDataStore((state) => state.hasData);
+  const handleComingSoon = () => {
+    sweetAlertUtil.info('곧 만나요!', '해당 기능은 곧 업데이트될 예정입니다');
+  };
 
   return (
     <div className='flex gap-2'>
@@ -32,11 +36,17 @@ const ExportButtons = () => {
         </>
       ) : (
         <>
-          <button className='flex gap-1 px-2 py-1 text-label2-regular text-primary-40'>
+          <button
+            onClick={handleComingSoon}
+            className='flex gap-1 px-2 py-1 text-label2-regular text-primary-40'
+          >
             <CsvIcon />
             CSV
           </button>
-          <button className='flex gap-1 px-2 py-1 text-label2-regular text-primary-40'>
+          <button
+            onClick={handleComingSoon}
+            className='flex gap-1 px-2 py-1 text-label2-regular text-primary-40'
+          >
             <PdfIcon />
             PDF
           </button>

--- a/src/components/card-detail/left-nav-section.tsx
+++ b/src/components/card-detail/left-nav-section.tsx
@@ -74,7 +74,7 @@ const LeftNavSection = () => {
     if (slug && slugToUrl) {
       openShareModal({
         cardId: cardId,
-        linkUrl: `${origin}/${slug}?source=direct`,
+        linkUrl: `${origin}/${slug}?source=link`,
         title: `${nickName}의 명함`,
         imageUrl: slugToUrl ?? '',
         description: 'Uuno에서 생성한 명함',

--- a/src/components/dashboard/card-edit-dropdown.tsx
+++ b/src/components/dashboard/card-edit-dropdown.tsx
@@ -60,7 +60,7 @@ const CardEditDropdown = ({
     if (slug) {
       openShareModal({
         cardId,
-        linkUrl: `${origin}/${slug}?source=direct`,
+        linkUrl: `${origin}/${slug}?source=link`,
         title: `${nickName}의 명함`,
         imageUrl,
         description: 'Uuno에서 생성한 명함',


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #262

<br>

## 📝 작업 내용

- 명함 상세 pdf + csv 기능 활성화 이전 안내 문구 창 추가
- 공유된 명함 페이지 기능 활성화 이전 안내 문구 창 추가

<br>

## 🖼 스크린샷


https://github.com/user-attachments/assets/cdb83558-4f3d-4da2-8f9c-f900c4fa942b


https://github.com/user-attachments/assets/ff4d17ba-8d8a-40f9-b7ec-3f9dbd09d283



<br>

## 💬 리뷰 요구사항

> 해당 알럿 문구 "'곧 만나요!', '해당 기능은 곧 업데이트될 예정입니다'"면 적당할까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 내보내기(CSV, PDF) 버튼 클릭 시 "곧 만나요!" 안내 알림이 표시됩니다.
  - "연락처 저장" 버튼 클릭 시 해당 기능이 곧 제공될 예정임을 알리는 안내 알림이 표시됩니다.

- **기타**
  - 공유 링크의 출처 표시가 'direct'에서 'link'로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->