### PR TITLE
[BUG FIX] #273 소셜 미리보기 변수 수정

### DIFF
--- a/src/components/editor/elements/qr-social/qrsocial-sidebar.tsx
+++ b/src/components/editor/elements/qr-social/qrsocial-sidebar.tsx
@@ -167,12 +167,12 @@ const QrSidebar = () => {
         const updatedList = [...prev];
         updatedList[existIcon] = {
           ...updatedList[existIcon],
-          url: socialCleanInput,
+          url: socialFullUrl,
         };
         return updatedList;
       }
 
-      return [...prev, { icon: social, url: socialCleanInput }];
+      return [...prev, { icon: social, url: socialFullUrl }];
     });
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #273 

<br>

## 📝 작업 내용

- 소셜 url에 들어가는 변수 socialCleanup에서 socialFullUrl로 변경

<br>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 소셜 미리보기 목록에 전체 소셜 URL이 일관되게 표시되도록 개선되었습니다. 이제 입력값 대신 완성된 전체 URL이 미리보기 목록에 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->