### PR TITLE
[BUGFIX] #277 템플릿, 내 명함으로 들어왔을 때 작업내용 증발되는 상황

### DIFF
--- a/src/components/layouts/editor-nav-bar.tsx
+++ b/src/components/layouts/editor-nav-bar.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/navigation';
 import { useSluggedSaveCard } from '@/hooks/use-slugged-save-card';
 import { resetEditorState } from '@/utils/editor/editor-reset-state';
 import { sideBarStore } from '@/store/editor.sidebar.store';
+import { useShallow } from 'zustand/react/shallow';
 
 interface Props {
   // Supabase Auth의 User 타입
@@ -21,21 +22,27 @@ const EditorNavBar = ({ user }: Props) => {
   const setIsOpen = modalStore((state) => state.setIsOpen);
   const setModalState = modalStore((state) => state.setModalState);
   const setSideBarStatus = sideBarStore((state) => state.setSideBarStatus);
+
+  const {
+    canvasElements,
+    canvasBackElements,
+    backgroundColor,
+    backgroundColorBack,
+    reset,
+  } = useEditorStore(
+    useShallow((state) => ({
+      canvasElements: state.canvasElements,
+      canvasBackElements: state.canvasBackElements,
+      backgroundColor: state.backgroundColor,
+      backgroundColorBack: state.backgroundColorBack,
+      reset: state.reset,
+    }))
+  );
+
   const route = useRouter();
   const { handleSave, isPending } = useSluggedSaveCard();
   const menuLinkStyle =
     'inline-block p-5 text-label1-medium transition-colors hover:text-primary-40';
-
-  const canvasElements = useEditorStore((state) => state.canvasElements);
-  const canvasBackElements = useEditorStore(
-    (state) => state.canvasBackElements
-  );
-  const isCanvasFront = useEditorStore((state) => state.isCanvasFront);
-  const reset = useEditorStore((state) => state.reset);
-
-  const currentCanvasElements = isCanvasFront
-    ? canvasElements
-    : canvasBackElements;
 
   const navigateTo = (link: string) => {
     setSideBarStatus(false);
@@ -86,9 +93,15 @@ const EditorNavBar = ({ user }: Props) => {
     });
   };
 
+  const isCurrentElement =
+    canvasElements.length === 0 &&
+    canvasBackElements.length === 0 &&
+    !backgroundColor &&
+    !backgroundColorBack;
+
   const handleOnClick = (link: string) => {
     // 저장할 내용이 없으면 바로 이동
-    if (currentCanvasElements.length === 0) {
+    if (isCurrentElement) {
       navigateTo(link);
       return;
     }

--- a/src/components/template-list/template-card.tsx
+++ b/src/components/template-list/template-card.tsx
@@ -4,8 +4,6 @@ import { Templates } from '@/types/supabase.type';
 import Image from 'next/image';
 import { CommonButton } from '../common/common-button';
 import { useRouter } from 'next/navigation';
-import { CardContent } from '@/types/editor.type';
-import { useEditorStore } from '@/store/editor.store';
 
 interface Props {
   template: Templates;
@@ -15,37 +13,9 @@ interface Props {
 const TemplateCard = ({ template, onPreview }: Props) => {
   const router = useRouter();
 
-  const setTemplate = useEditorStore((state) => state.setTemplate);
-  const setCanvasElements = useEditorStore((state) => state.setCanvasElements);
-  const setCanvasBackElements = useEditorStore(
-    (state) => state.setCanvasBackElements
-  );
-  const setBackgroundColor = useEditorStore(
-    (state) => state.setBackgroundColor
-  );
-  const setBackgroundColorBack = useEditorStore(
-    (state) => state.setBackgroundColorBack
-  );
-
   //템플릿 적용 핸들러
   const handleApplyTemplate = () => {
     router.push(`/editor?templateId=${template.id}`);
-    if (!template.content) return;
-    const content = template.content as CardContent;
-    setTemplate(template);
-
-    if (content.canvasElements) {
-      setCanvasElements(content.canvasElements);
-    }
-    if (content.backgroundColor) {
-      setBackgroundColor(content.backgroundColor);
-    }
-    if (content.canvasBackElements) {
-      setCanvasBackElements(content.canvasBackElements);
-    }
-    if (content.backgroundColorBack) {
-      setBackgroundColorBack(content.backgroundColorBack);
-    }
   };
 
   return (

--- a/src/hooks/queries/use-template-single.ts
+++ b/src/hooks/queries/use-template-single.ts
@@ -1,13 +1,13 @@
 import { getSingleData } from '@/apis/common-server.api';
 import { QUERY_KEY } from '@/constants/query-key';
-import { Templates } from '@/types/supabase.type';
+import { TemplateData } from '@/types/templates.type';
 import { useQuery } from '@tanstack/react-query';
 
 export const getTemplateData = (templateId: string) => {
   return useQuery({
     queryKey: [QUERY_KEY.TEMPLATES, templateId],
     queryFn: async () => {
-      const { data } = await getSingleData<Templates>({
+      const { data } = await getSingleData<TemplateData>({
         table: 'templates',
         field: 'id',
         value: templateId,

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -60,13 +60,6 @@ export type Database = {
             referencedRelation: "cards"
             referencedColumns: ["id"]
           },
-          {
-            foreignKeyName: "card_views_viewer_id_fkey"
-            columns: ["viewer_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
         ]
       }
       cards: {
@@ -90,7 +83,7 @@ export type Database = {
           created_at?: string
           frontImgURL?: string | null
           id?: string
-          isHorizontal?: boolean
+          isHorizontal: boolean
           slug: string
           status?: Database["public"]["Enums"]["cards_status"] | null
           template_id?: string | null
@@ -121,7 +114,7 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "cards_user_id_fkey1"
+            foreignKeyName: "cards_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "users"
@@ -138,7 +131,7 @@ export type Database = {
           url: string | null
         }
         Insert: {
-          card_id?: string
+          card_id: string
           icon_path?: string | null
           id?: string
           platform?: string | null
@@ -163,25 +156,25 @@ export type Database = {
       }
       templates: {
         Row: {
-          content: Json | null
+          content: Json
           id: string
-          isHorizontal: boolean | null
+          isHorizontal: boolean
           name: string
           style: Database["public"]["Enums"]["templates_style"] | null
           thumbnail: string | null
         }
         Insert: {
-          content?: Json | null
+          content: Json
           id?: string
-          isHorizontal?: boolean | null
+          isHorizontal: boolean
           name: string
           style?: Database["public"]["Enums"]["templates_style"] | null
           thumbnail?: string | null
         }
         Update: {
-          content?: Json | null
+          content?: Json
           id?: string
-          isHorizontal?: boolean | null
+          isHorizontal?: boolean
           name?: string
           style?: Database["public"]["Enums"]["templates_style"] | null
           thumbnail?: string | null

--- a/src/types/templates.type.ts
+++ b/src/types/templates.type.ts
@@ -1,0 +1,18 @@
+import { CanvasElements } from './editor.type';
+
+export interface TemplateContent {
+  canvasElements: CanvasElements[];
+  backgroundColor: string | null;
+  canvasBackElements: CanvasElements[];
+  backgroundColorBack: string | null;
+  isTemplate: boolean;
+}
+
+export interface TemplateData {
+  content: TemplateContent;
+  name: string;
+  thumbnail: string;
+  id: string;
+  isHorizontal: boolean;
+  style: 'trendy' | 'simple';
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #277 
- close #278 

<br>

## 📝 작업 내용

- 세션스토리지 데이터 받아온 후 세션스토리지 유무에 따라 데이터 페치 
- 템플릿에서 에디터로 넘어올 때 zustand로 넘겨주는 데이터 제거
- 템플릿에서 params로 넘겨온 데이터로 에디터에서 데이터 가공 후 데이터 페치

<br>

## 🖼 스크린샷

https://github.com/user-attachments/assets/70537cae-bab6-4226-8db9-8d3d0875ef5b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 에디터 상태 초기화 및 저장 방식 개선으로 세션 스토리지와 템플릿 데이터를 우선적으로 활용합니다.
	- 상태 관리 훅의 사용 방식을 통합하여 성능과 코드 효율성을 높였습니다.
- **Bug Fixes**
	- 템플릿 적용 시 불필요한 에디터 상태 변경 없이 페이지 이동만 처리하도록 수정되었습니다.
- **Types**
	- 템플릿 및 카드 데이터 타입이 명확하게 정의되고 필수 필드가 강화되었습니다.
- **New Features**
	- 템플릿 데이터 구조에 대한 타입 정의가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->