### PR TITLE
[BUGFIX] #285 세션스토리지 버그 픽스

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -11,7 +11,7 @@ import { useEditorStore } from '@/store/editor.store';
 import { CardContent } from '@/types/cards.type';
 import { TemplateContent } from '@/types/templates.type';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
 const EditPage = () => {
@@ -28,10 +28,6 @@ const EditPage = () => {
     isError,
     isPending,
   } = getTemplateData(templateId);
-
-  const sessionData = sessionStorage.getItem('editor-storage');
-  if (!sessionData) return;
-  const sessionContent = JSON.parse(sessionData).state;
 
   const {
     redo,
@@ -66,11 +62,31 @@ const EditPage = () => {
     setBackgroundColorBack(content.backgroundColorBack);
   };
 
+  const [sessionContent, setSessionContent] = useState({
+    canvasElements: [],
+    canvasBackElements: [],
+    backgroundColor: '',
+    backgroundColorBack: '',
+    title: '',
+  });
+
   const isSessionContent =
     sessionContent.canvasElements.length > 0 ||
-    sessionContent.canvasBackElements > 0 ||
+    sessionContent.canvasBackElements.length > 0 ||
     sessionContent.backgroundColor ||
     sessionContent.backgroundColorBack;
+
+  // sessionStorage 접근을 클라이언트 측에서만 실행되도록 useEffect 내부로 이동
+  useEffect(() => {
+    const sessionData = sessionStorage.getItem('editor-storage');
+    if (sessionData) {
+      try {
+        setSessionContent(JSON.parse(sessionData).state);
+      } catch (error) {
+        console.error('세션 데이터 파싱 실패:', error);
+      }
+    }
+  }, []);
 
   // 내 명함 데이터
   useEffect(() => {
@@ -84,7 +100,7 @@ const EditPage = () => {
       const { content } = templateData;
       setCommonCanvasData(content);
     }
-  }, [data, templateData, sessionData]);
+  }, [data, templateData, sessionContent]);
 
   // undo redo 커맨드 키
   useEffect(() => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #285

<br>

## 📝 작업 내용

- 세션스토리지가 클라이언트에서만 작동하도록 useEffect안에 감쌈




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터링**
  - 세션 저장소 데이터를 컴포넌트 상태로 관리하도록 개선하여, 클라이언트 사이드에서 안전하게 데이터를 불러오고 처리하도록 변경되었습니다.  
  - 세션 데이터가 컴포넌트 라이프사이클에 맞게 반영되어, 데이터 동기화와 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->