### PR TITLE
[BUGFIX]#294 명함 삭제 후 리다이렉션 시 최신 데이터가 반영되지 않는 문제 수정

### DIFF
--- a/src/components/card-detail/left-nav-section.tsx
+++ b/src/components/card-detail/left-nav-section.tsx
@@ -45,9 +45,9 @@ const LeftNavSection = () => {
 
       // 삭제 후 리다이렉션 처리
       if (updatedCardList && updatedCardList.length > 0) {
-        router.push(`/card/${updatedCardList[0].id}`);
+        router.push(`${ROUTES.MYCARD}/${updatedCardList[0].id}`);
       } else {
-        router.push('/dashboard');
+        router.push(ROUTES.DASHBOARD.BASE);
       }
     },
   });

--- a/src/components/card-detail/left-nav-section.tsx
+++ b/src/components/card-detail/left-nav-section.tsx
@@ -40,21 +40,22 @@ const LeftNavSection = () => {
     slug: slug ?? '',
     cardId,
     userId,
+    onDeleteSuccess: (updatedCardList) => {
+      sweetAlertUtil.success('삭제 성공', '명함이 성공적으로 삭제되었습니다.');
+
+      // 삭제 후 리다이렉션 처리
+      if (updatedCardList && updatedCardList.length > 0) {
+        router.push(`/card/${updatedCardList[0].id}`);
+      } else {
+        router.push('/dashboard');
+      }
+    },
   });
 
-  const handleDeleteCard = async () => {
-    customSweetAlert.confirmCardDelete(async () => {
+  const handleDeleteCard = () => {
+    customSweetAlert.confirmCardDelete(() => {
       try {
-        await deleteMutate();
-        sweetAlertUtil.success(
-          '삭제 성공',
-          '명함이 성공적으로 삭제되었습니다.'
-        );
-        if (data && data.length > 0) {
-          router.push(`/card/${data[0].id}`);
-        } else {
-          router.push('/dashboard');
-        }
+        deleteMutate();
       } catch (error) {
         sweetAlertUtil.error(
           '삭제 실패',

--- a/src/hooks/mutations/use-mycard-delete.ts
+++ b/src/hooks/mutations/use-mycard-delete.ts
@@ -1,19 +1,26 @@
 import { deleteCard } from '@/apis/card-delete';
 import { QUERY_KEY } from '@/constants/query-key';
+import { Cards } from '@/types/supabase.type';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 interface Props {
   slug: string;
   cardId: string;
   userId: string;
+  onDeleteSuccess?: (updatedCardList?: Cards[]) => void;
 }
 
-export const useMyCardDelete = ({ cardId, slug, userId }: Props) => {
+export const useMyCardDelete = ({
+  cardId,
+  slug,
+  userId,
+  onDeleteSuccess,
+}: Props) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: () => deleteCard({ cardId, slug, userId }),
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({
         // 명함 목록 다시 가져오기
         queryKey: [QUERY_KEY.CARD_LIST, userId],
@@ -27,6 +34,16 @@ export const useMyCardDelete = ({ cardId, slug, userId }: Props) => {
         queryClient.invalidateQueries({
           queryKey: [QUERY_KEY.MONTH_STATS, userId],
         });
+      await queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.CARD_SELECT_LIST, userId],
+      });
+      const updatedData = await queryClient.fetchQuery<Cards[]>({
+        queryKey: [QUERY_KEY.CARD_SELECT_LIST, userId],
+      });
+
+      if (onDeleteSuccess) {
+        onDeleteSuccess(updatedData);
+      }
     },
     onError: (error) => {
       console.error('카드 삭제 중 오류 발생 : ', error);

--- a/src/hooks/queries/use-card-select-list.ts
+++ b/src/hooks/queries/use-card-select-list.ts
@@ -2,14 +2,14 @@ import { getCardSelectList } from '@/apis/card-select-list';
 import { QUERY_KEY } from '@/constants/query-key';
 import { useQuery } from '@tanstack/react-query';
 
-const useCardSelectList = (user_id: string) => {
+const useCardSelectList = (userId: string) => {
   return useQuery({
-    queryKey: [QUERY_KEY.CARD_SELECT_LIST],
+    queryKey: [QUERY_KEY.CARD_SELECT_LIST, userId],
     queryFn: async () => {
-      if (user_id === '') return null;
-      return getCardSelectList(user_id);
+      if (userId === '') return null;
+      return getCardSelectList(userId);
     },
-    enabled: !!user_id,
+    enabled: !!userId,
   });
 };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #294

<br>

## 📝 작업 내용

- 명함 삭제 후 리다이렉션 시 최신 데이터가 반영되지 않는 문제 수정
- useMyCardDelete 훅에 onDeleteSuccess 콜백 추가하여 삭제 후 처리 개선

<br>

## 🖼 스크린샷


<br>

## 💬 리뷰 요구사항

> 없습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 카드 삭제 후 성공 알림이 표시되고, 카드 목록이 갱신되어 첫 번째 카드 또는 대시보드로 자동 이동됩니다.
  - 카드 선택 목록이 사용자별로 정확하게 갱신됩니다.

- **스타일**
  - 일부 파라미터 명칭이 일관성 있게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->