### PR TITLE
Feat/#281 에디터 저장 편집시 기존 업데이트

### DIFF
--- a/src/apis/card-update.ts
+++ b/src/apis/card-update.ts
@@ -1,0 +1,21 @@
+import { createClient } from '@/utils/supabase/client';
+import { CardData } from '@/types/cards.type';
+import { TablesUpdate } from '@/types/supabase';
+
+export const updateCard = async ({
+  id,
+  payload,
+}: {
+  id: string;
+  payload: TablesUpdate<'cards'>;
+}) => {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('cards')
+    .update(payload)
+    .eq('id', id)
+    .single<CardData>();
+
+  if (error) throw error;
+  return data!;
+};

--- a/src/apis/common-client.api.ts
+++ b/src/apis/common-client.api.ts
@@ -7,12 +7,12 @@ interface SingleDataProps<T> {
   value: string;
 }
 
-export const getSingleData = async <T>({
+export const getSingleDataByClient = async <T>({
   table,
   field,
   value,
 }: SingleDataProps<T>) => {
-  const supabase = await createClient();
+  const supabase = createClient();
   const { data, error } = await supabase
     .from(table)
     .select('*')

--- a/src/apis/common-client.api.ts
+++ b/src/apis/common-client.api.ts
@@ -1,0 +1,23 @@
+import { TABLES } from '@/constants/tables.constant';
+import { createClient } from '@/utils/supabase/client';
+
+interface SingleDataProps<T> {
+  table: (typeof TABLES)[keyof typeof TABLES];
+  field: string;
+  value: string;
+}
+
+export const getSingleData = async <T>({
+  table,
+  field,
+  value,
+}: SingleDataProps<T>) => {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from(table)
+    .select('*')
+    .eq(field, value)
+    .single<T>();
+
+  return { data, error };
+};

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -95,14 +95,13 @@ const EditPage = () => {
   // 내 명함 데이터
   useEffect(() => {
     if (isSessionContent) {
+      setTitle(sessionContent.title);
       setCommonCanvasData(sessionContent);
     } else if (cardData) {
-      const { content, title } = cardData;
-      setTitle(title);
-      setCommonCanvasData(content);
+      setTitle(cardData.title);
+      setCommonCanvasData(cardData.content);
     } else if (templateData) {
-      const { content } = templateData;
-      setCommonCanvasData(content);
+      setCommonCanvasData(templateData.content);
     }
   }, [cardData, templateData, sessionContent]);
 

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -5,7 +5,7 @@ import EditorBottomTab from '@/components/editor/editor-ui/bottomTab/editor-bott
 import EditorSideBar from '@/components/editor/editor-ui/sidebar/editor-sidebar';
 import EditorTopbar from '@/components/editor/editor-ui/topbar/editor-topbar';
 import CanvasSelectModal from '@/components/editor/modal/editor-vt-hr-select-modal';
-import { useCardContent } from '@/hooks/queries/use-card-interaction';
+import { useCardDataById } from '@/hooks/queries/use-card-by-id-single';
 import { getTemplateData } from '@/hooks/queries/use-template-single';
 import { useEditorStore } from '@/store/editor.store';
 import { CardContent } from '@/types/cards.type';
@@ -16,12 +16,16 @@ import { useShallow } from 'zustand/react/shallow';
 
 const EditPage = () => {
   const params = useSearchParams();
-  const slug = params.get('slug') || '';
+  const cardId = params.get('cardId') || '';
   const templateId = params.get('templateId') || '';
 
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const { data } = useCardContent(slug);
+  const {
+    data: cardData,
+    isError: cardIsError,
+    isPending: cardIsPending,
+  } = useCardDataById(cardId);
 
   const {
     data: templateData,
@@ -92,15 +96,15 @@ const EditPage = () => {
   useEffect(() => {
     if (isSessionContent) {
       setCommonCanvasData(sessionContent);
-    } else if (data) {
-      const { content, title } = data;
+    } else if (cardData) {
+      const { content, title } = cardData;
       setTitle(title);
       setCommonCanvasData(content);
     } else if (templateData) {
       const { content } = templateData;
       setCommonCanvasData(content);
     }
-  }, [data, templateData, sessionContent]);
+  }, [cardData, templateData, sessionContent]);
 
   // undo redo 커맨드 키
   useEffect(() => {
@@ -129,10 +133,12 @@ const EditPage = () => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [undo, redo]);
 
-  const isHorizontal = data ? data.isHorizontal : templateData?.isHorizontal;
+  const isHorizontal = cardData
+    ? cardData.isHorizontal
+    : templateData?.isHorizontal;
 
-  if (isError) return <>...Error</>;
-  if (isPending) return <>...loading</>;
+  if (isError || cardIsError) return <>...Error</>;
+  if (isPending || cardIsPending) return <>...loading</>;
 
   return (
     <div className='flex h-[calc(100vh-64px)] flex-row overflow-hidden'>

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -40,6 +40,7 @@ const EditPage = () => {
     setCanvasBackElements,
     setBackgroundColorBack,
     setTitle,
+    setSlug,
   } = useEditorStore(
     useShallow((state) => ({
       redo: state.redo,
@@ -52,6 +53,7 @@ const EditPage = () => {
       setCanvasBackElements: state.setCanvasBackElements,
       setBackgroundColorBack: state.setBackgroundColorBack,
       setTitle: state.setTitle,
+      setSlug: state.setSlug,
     }))
   );
 
@@ -96,10 +98,11 @@ const EditPage = () => {
     } else if (cardData) {
       setTitle(cardData.title);
       setCommonCanvasData(cardData.content);
+      setSlug(cardData.slug);
     } else if (templateData) {
       setCommonCanvasData(templateData.content);
     }
-  }, [cardData, templateData, sessionContent]);
+  }, [cardData, templateData, sessionContent, setSlug]);
 
   // undo redo 커맨드 키
   useEffect(() => {

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -18,9 +18,7 @@ const EditPage = () => {
   const params = useSearchParams();
   const cardId = params.get('cardId') || '';
   const templateId = params.get('templateId') || '';
-
   const containerRef = useRef<HTMLDivElement>(null);
-
   const { data: cardData } = useCardDataById(cardId);
 
   const {

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -21,11 +21,7 @@ const EditPage = () => {
 
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const {
-    data: cardData,
-    isError: cardIsError,
-    isPending: cardIsPending,
-  } = useCardDataById(cardId);
+  const { data: cardData } = useCardDataById(cardId);
 
   const {
     data: templateData,
@@ -136,8 +132,8 @@ const EditPage = () => {
     ? cardData.isHorizontal
     : templateData?.isHorizontal;
 
-  if (isError || cardIsError) return <>...Error</>;
-  if (isPending || cardIsPending) return <>...loading</>;
+  if (isError) return <>...Error</>;
+  if (isPending) return <>...loading</>;
 
   return (
     <div className='flex h-[calc(100vh-64px)] flex-row overflow-hidden'>

--- a/src/components/card-detail/left-nav-section.tsx
+++ b/src/components/card-detail/left-nav-section.tsx
@@ -24,7 +24,6 @@ const LeftNavSection = () => {
   const [origin, setOrigin] = useState<string>('');
   const userId = authStore((state) => state.userId!);
   const router = useRouter();
-
   const {
     data: slug,
     isError: getSlugError,
@@ -103,7 +102,7 @@ const LeftNavSection = () => {
         <div className='flex w-full flex-col items-center justify-center'>
           <FlipCard isDetail={true} />
           <Link
-            href={`${ROUTES.EDITOR}?slug=${slug}`}
+            href={`${ROUTES.EDITOR}?cardId=${cardId}`}
             className='mx-2 mb-2 flex w-full justify-center rounded-full bg-primary-40 px-3 py-[10px] text-label2-regular text-white'
           >
             편집하기

--- a/src/components/dashboard/card-edit-dropdown.tsx
+++ b/src/components/dashboard/card-edit-dropdown.tsx
@@ -169,7 +169,7 @@ const CardEditDropdown = ({
           </DropdownMenuItem>
 
           <DropdownMenuItem asChild>
-            <Link href={`${ROUTES.EDITOR}?slug=${slug}`}>
+            <Link href={`${ROUTES.EDITOR}?cardId=${cardId}`}>
               <Icon icon='tdesign:edit-2' width='18' height='18' />
               편집하기
             </Link>

--- a/src/components/editor/elements/qr-social/qrsocial-sidebar.tsx
+++ b/src/components/editor/elements/qr-social/qrsocial-sidebar.tsx
@@ -72,7 +72,7 @@ const QrSidebar = () => {
     setIsCheckingSlug(true);
     try {
       const exists = await checkSlugExists(slug);
-      if (exists) {
+      if (exists && slug !== hasSlug) {
         await sweetAlertUtil.error(
           '이미 사용 중인 주소입니다.',
           ' 다른 주소를 입력해주세요.'

--- a/src/components/editor/elements/qr-social/qrsocial-sidebar.tsx
+++ b/src/components/editor/elements/qr-social/qrsocial-sidebar.tsx
@@ -42,6 +42,7 @@ const QrSidebar = () => {
   );
   const setToolbar = useEditorStore((state) => state.setToolbar);
   const setSlug = useEditorStore((state) => state.setSlug);
+  const hasSlug = useEditorStore((state) => state.slug);
 
   const {
     register,
@@ -227,7 +228,7 @@ const QrSidebar = () => {
                 <input
                   type='text'
                   {...register('slug')}
-                  placeholder='URL 입력'
+                  placeholder={hasSlug ?? 'URL 입력'}
                   className='w-full bg-transparent outline-none'
                   style={{ whiteSpace: 'nowrap' }}
                 />

--- a/src/components/layouts/editor-nav-bar.tsx
+++ b/src/components/layouts/editor-nav-bar.tsx
@@ -13,12 +13,7 @@ import { resetEditorState } from '@/utils/editor/editor-reset-state';
 import { sideBarStore } from '@/store/editor.sidebar.store';
 import { useShallow } from 'zustand/react/shallow';
 
-interface Props {
-  // Supabase Auth의 User 타입
-  user: UserMetadata | null;
-}
-
-const EditorNavBar = ({ user }: Props) => {
+const EditorNavBar = ({ user }: UserMetadata) => {
   const setIsOpen = modalStore((state) => state.setIsOpen);
   const setModalState = modalStore((state) => state.setModalState);
   const setSideBarStatus = sideBarStore((state) => state.setSideBarStatus);
@@ -66,7 +61,7 @@ const EditorNavBar = ({ user }: Props) => {
       showLoginModal();
       return;
     }
-    handleSave();
+    handleSave(user);
   };
 
   const discardChangesAndNavigate = (link: string) => {
@@ -86,7 +81,7 @@ const EditorNavBar = ({ user }: Props) => {
       denyButtonText: '저장하지 않고 나가기',
     }).then((result) => {
       if (result.isConfirmed) {
-        handleSave();
+        handleSave(user);
       } else if (result.isDenied) {
         discardChangesAndNavigate(link);
       }

--- a/src/components/layouts/editor-nav-bar.tsx
+++ b/src/components/layouts/editor-nav-bar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { UserMetadata } from '@supabase/supabase-js';
+import { User, UserMetadata } from '@supabase/supabase-js';
 import { ROUTES } from '@/constants/path.constant';
 import { modalStore } from '@/store/modal.store';
 import Image from 'next/image';
@@ -14,7 +14,7 @@ import { sideBarStore } from '@/store/editor.sidebar.store';
 import { useShallow } from 'zustand/react/shallow';
 
 interface EditorNavBarProps {
-  user: UserMetadata | null;
+  user: User | null;
 }
 
 const EditorNavBar = ({ user }: EditorNavBarProps) => {

--- a/src/components/layouts/editor-nav-bar.tsx
+++ b/src/components/layouts/editor-nav-bar.tsx
@@ -13,7 +13,11 @@ import { resetEditorState } from '@/utils/editor/editor-reset-state';
 import { sideBarStore } from '@/store/editor.sidebar.store';
 import { useShallow } from 'zustand/react/shallow';
 
-const EditorNavBar = ({ user }: UserMetadata) => {
+interface EditorNavBarProps {
+  user: UserMetadata | null;
+}
+
+const EditorNavBar = ({ user }: EditorNavBarProps) => {
   const setIsOpen = modalStore((state) => state.setIsOpen);
   const setModalState = modalStore((state) => state.setModalState);
   const setSideBarStatus = sideBarStore((state) => state.setSideBarStatus);
@@ -81,7 +85,11 @@ const EditorNavBar = ({ user }: UserMetadata) => {
       denyButtonText: '저장하지 않고 나가기',
     }).then((result) => {
       if (result.isConfirmed) {
-        handleSave(user);
+        if (!user) {
+          showLoginModal();
+        } else {
+          handleSave(user);
+        }
       } else if (result.isDenied) {
         discardChangesAndNavigate(link);
       }

--- a/src/constants/query-key.ts
+++ b/src/constants/query-key.ts
@@ -18,5 +18,6 @@ export const QUERY_KEY = {
   DURATION_MONTHLY: 'duration-monthly',
   STORAGEUSAGE: 'storage-usage',
   CARD_LIST: 'card-list',
-  SOURCE_CNT_WEEK: 'source-cnt-week'
+  SOURCE_CNT_WEEK: 'source-cnt-week',
+  CARD: 'card',
 };

--- a/src/hooks/mutations/use-card-update.ts
+++ b/src/hooks/mutations/use-card-update.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { CardData } from '@/types/cards.type';
+import { updateCard } from '@/apis/card-update';
+import { TablesUpdate } from '@/types/supabase';
+
+export const useCardUpdate = () => {
+  return useMutation<
+    CardData,
+    Error,
+    { id: string; payload: TablesUpdate<'cards'> }
+  >({
+    mutationFn: updateCard,
+  });
+};

--- a/src/hooks/queries/use-card-by-id-single.ts
+++ b/src/hooks/queries/use-card-by-id-single.ts
@@ -1,4 +1,4 @@
-import { getSingleData } from '@/apis/common-server.api';
+import { getSingleDataByClient } from '@/apis/common-client.api';
 import { CardData } from '@/types/cards.type';
 import { useQuery } from '@tanstack/react-query';
 
@@ -6,7 +6,7 @@ export const useCardDataById = (cardId: string) =>
   useQuery({
     queryKey: ['card', cardId],
     queryFn: async () => {
-      const { data, error } = await getSingleData<CardData>({
+      const { data, error } = await getSingleDataByClient<CardData>({
         table: 'cards',
         field: 'id',
         value: cardId,

--- a/src/hooks/queries/use-card-by-id-single.ts
+++ b/src/hooks/queries/use-card-by-id-single.ts
@@ -1,13 +1,15 @@
 import { getSingleDataByClient } from '@/apis/common-client.api';
+import { QUERY_KEY } from '@/constants/query-key';
+import { TABLES } from '@/constants/tables.constant';
 import { CardData } from '@/types/cards.type';
 import { useQuery } from '@tanstack/react-query';
 
 export const useCardDataById = (cardId: string) =>
   useQuery({
-    queryKey: ['card', cardId],
+    queryKey: [QUERY_KEY.CARD, cardId],
     queryFn: async () => {
       const { data, error } = await getSingleDataByClient<CardData>({
-        table: 'cards',
+        table: TABLES.CARDS,
         field: 'id',
         value: cardId,
       });

--- a/src/hooks/queries/use-card-by-id-single.ts
+++ b/src/hooks/queries/use-card-by-id-single.ts
@@ -1,0 +1,17 @@
+import { getSingleData } from '@/apis/common-server.api';
+import { CardData } from '@/types/cards.type';
+import { useQuery } from '@tanstack/react-query';
+
+export const useCardDataById = (cardId: string) => {
+  return useQuery({
+    queryKey: ['card', cardId],
+    queryFn: async () => {
+      const { data } = await getSingleData<CardData>({
+        table: 'cards',
+        field: 'id',
+        value: cardId,
+      });
+      return data;
+    },
+  });
+};

--- a/src/hooks/queries/use-card-by-id-single.ts
+++ b/src/hooks/queries/use-card-by-id-single.ts
@@ -2,16 +2,17 @@ import { getSingleData } from '@/apis/common-server.api';
 import { CardData } from '@/types/cards.type';
 import { useQuery } from '@tanstack/react-query';
 
-export const useCardDataById = (cardId: string) => {
-  return useQuery({
+export const useCardDataById = (cardId: string) =>
+  useQuery({
     queryKey: ['card', cardId],
     queryFn: async () => {
-      const { data } = await getSingleData<CardData>({
+      const { data, error } = await getSingleData<CardData>({
         table: 'cards',
         field: 'id',
         value: cardId,
       });
-      return data;
+      if (error) throw error;
+      return data!;
     },
+    enabled: !!cardId,
   });
-};

--- a/src/hooks/use-slugged-save-card.ts
+++ b/src/hooks/use-slugged-save-card.ts
@@ -14,8 +14,10 @@ import { getStageImageUrls } from '@/utils/editor/save/get-state-image-url';
 import { UserMetadata } from '@supabase/supabase-js';
 import { createCardUpdatePayload } from '@/utils/editor/save/create-card-update-payload';
 import { useCardUpdate } from '@/hooks/mutations/use-card-update';
+import { useQueryClient } from '@tanstack/react-query';
 
 export const useSluggedSaveCard = () => {
+  const queryClient = useQueryClient();
   const params = useSearchParams();
   const cardId = params.get('cardId') || '';
   const router = useRouter();
@@ -67,6 +69,9 @@ export const useSluggedSaveCard = () => {
           { id: cardId, payload },
           {
             onSuccess: () => {
+              queryClient.invalidateQueries({
+                queryKey: ['card', cardId],
+              });
               sweetAlertUtil.success('수정 성공', '명함이 수정되었습니다.');
               resetEditorState();
               router.push(ROUTES.DASHBOARD.MYCARDS);

--- a/src/hooks/use-slugged-save-card.ts
+++ b/src/hooks/use-slugged-save-card.ts
@@ -14,10 +14,8 @@ import { getStageImageUrls } from '@/utils/editor/save/get-state-image-url';
 import { UserMetadata } from '@supabase/supabase-js';
 import { createCardUpdatePayload } from '@/utils/editor/save/create-card-update-payload';
 import { useCardUpdate } from '@/hooks/mutations/use-card-update';
-import { useQueryClient } from '@tanstack/react-query';
 
 export const useSluggedSaveCard = () => {
-  const queryClient = useQueryClient();
   const params = useSearchParams();
   const cardId = params.get('cardId') || '';
   const router = useRouter();
@@ -69,11 +67,9 @@ export const useSluggedSaveCard = () => {
           { id: cardId, payload },
           {
             onSuccess: () => {
-              queryClient.invalidateQueries({
-                queryKey: ['card', cardId],
-              });
               sweetAlertUtil.success('수정 성공', '명함이 수정되었습니다.');
               resetEditorState();
+              router.refresh();
               router.push(ROUTES.DASHBOARD.MYCARDS);
             },
             onError: (e) => {

--- a/src/hooks/use-slugged-save-card.ts
+++ b/src/hooks/use-slugged-save-card.ts
@@ -14,8 +14,10 @@ import { getStageImageUrls } from '@/utils/editor/save/get-state-image-url';
 import { UserMetadata } from '@supabase/supabase-js';
 import { createCardUpdatePayload } from '@/utils/editor/save/create-card-update-payload';
 import { useCardUpdate } from '@/hooks/mutations/use-card-update';
+import { useQueryClient } from '@tanstack/react-query';
 
 export const useSluggedSaveCard = () => {
+  const queryClient = useQueryClient();
   const params = useSearchParams();
   const cardId = params.get('cardId') || '';
   const router = useRouter();
@@ -67,6 +69,9 @@ export const useSluggedSaveCard = () => {
           { id: cardId, payload },
           {
             onSuccess: () => {
+              queryClient.invalidateQueries({
+                queryKey: ['card', cardId],
+              });
               sweetAlertUtil.success('수정 성공', '명함이 수정되었습니다.');
               resetEditorState();
               router.refresh();

--- a/src/hooks/use-slugged-save-card.ts
+++ b/src/hooks/use-slugged-save-card.ts
@@ -11,7 +11,7 @@ import { validateSlug } from '@/utils/editor/save/validate-slug';
 import { resetEditorState } from '@/utils/editor/editor-reset-state';
 import { createCardInsertPayload } from '@/utils/editor/save/create-card-insert-payload';
 import { getStageImageUrls } from '@/utils/editor/save/get-state-image-url';
-import { UserMetadata } from '@supabase/supabase-js';
+import { User, UserMetadata } from '@supabase/supabase-js';
 import { createCardUpdatePayload } from '@/utils/editor/save/create-card-update-payload';
 import { useCardUpdate } from '@/hooks/mutations/use-card-update';
 import { useQueryClient } from '@tanstack/react-query';
@@ -130,7 +130,7 @@ export const useSluggedSaveCard = () => {
    * 최종 저장 트리거 (슬러그/로그인 체크 포함)
    */
   const handleSave = useCallback(
-    async (user: UserMetadata) => {
+    async (user: User) => {
       let lastSlug: string | null = slug?.trim() || '';
       if (!lastSlug && !cardId) {
         lastSlug = await checkSlug();

--- a/src/hooks/use-slugged-save-card.ts
+++ b/src/hooks/use-slugged-save-card.ts
@@ -98,8 +98,8 @@ export const useSluggedSaveCard = () => {
             const isDup = e.message?.includes('duplicate key value');
             if (isDup) {
               await sweetAlertUtil.error(
-                '저장 실패',
-                '이미 사용 중인 주소입니다.'
+                '이미 사용 중인 주소입니다.',
+                '다른 주소를 입력해주세요.'
               );
               const newSlug = await checkSlug();
               if (newSlug) doSave(userId, newSlug);

--- a/src/hooks/use-slugged-save-card.ts
+++ b/src/hooks/use-slugged-save-card.ts
@@ -1,19 +1,21 @@
 'use client';
 import { useCallback } from 'react';
 import sweetAlertUtil from '@/utils/common/sweet-alert-util';
-import { createClient } from '@/utils/supabase/client';
 import { useCardSave } from '@/hooks/mutations/use-card-save';
 import { useEditorStore } from '@/store/editor.store';
 import { checkSlugExists } from '@/apis/check-slug-exists';
 import { useStageRefStore } from '@/store/editor.stage.store';
 import { ROUTES } from '@/constants/path.constant';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { validateSlug } from '@/utils/editor/save/validate-slug';
 import { resetEditorState } from '@/utils/editor/editor-reset-state';
 import { createCardInsertPayload } from '@/utils/editor/save/create-card-insert-payload';
 import { getStageImageUrls } from '@/utils/editor/save/get-state-image-url';
+import { UserMetadata } from '@supabase/supabase-js';
 
 export const useSluggedSaveCard = () => {
+  const params = useSearchParams();
+  const cardId = params.get('cardId') || '';
   const router = useRouter();
   const { mutate: saveCard, isPending } = useCardSave();
   const slug = useEditorStore((state) => state.slug);
@@ -94,39 +96,33 @@ export const useSluggedSaveCard = () => {
   /**
    * 최종 저장 트리거 (슬러그/로그인 체크 포함)
    */
-  const handleSave = useCallback(async () => {
-    const supabase = createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) {
-      await sweetAlertUtil.error('로그인 필요', '로그인이 필요합니다.');
-      return;
-    }
+  const handleSave = useCallback(
+    async (user: UserMetadata) => {
+      const lastSlug = slug?.trim() ? slug : await checkSlug();
+      if (!lastSlug) return;
 
-    const lastSlug = slug?.trim() ? slug : await checkSlug();
-    if (!lastSlug) return;
-
-    try {
-      const exists = await checkSlugExists(lastSlug);
-      if (exists) {
-        await sweetAlertUtil.error(
-          '이미 사용 중인 주소입니다.',
-          '다른 주소를 입력해주세요.'
-        );
-        const newSlug = await checkSlug();
-        if (newSlug) {
-          doSave(user.id, newSlug);
+      try {
+        const exists = await checkSlugExists(lastSlug);
+        if (exists) {
+          await sweetAlertUtil.error(
+            '이미 사용 중인 주소입니다.',
+            '다른 주소를 입력해주세요.'
+          );
+          const newSlug = await checkSlug();
+          if (newSlug) {
+            doSave(user.id, newSlug);
+          }
+          return;
         }
+      } catch (err) {
+        await sweetAlertUtil.error('알 수 없는 오류가 발생했습니다.');
         return;
       }
-    } catch (err) {
-      await sweetAlertUtil.error('알 수 없는 오류가 발생했습니다.');
-      return;
-    }
 
-    doSave(user.id, lastSlug);
-  }, [slug, checkSlug, doSave]);
+      doSave(user.id, lastSlug);
+    },
+    [slug, checkSlug, doSave]
+  );
 
   return { handleSave, isPending };
 };

--- a/src/utils/editor/save/create-card-update-payload.ts
+++ b/src/utils/editor/save/create-card-update-payload.ts
@@ -1,0 +1,32 @@
+import { sideBarStore } from '@/store/editor.sidebar.store';
+import { useEditorStore } from '@/store/editor.store';
+import { Json, TablesUpdate } from '@/types/supabase';
+
+export const createCardUpdatePayload = (
+  slug: string,
+  urls: Record<'front' | 'back', string>
+): TablesUpdate<'cards'> => {
+  const {
+    title,
+    canvasElements,
+    canvasBackElements,
+    backgroundColor,
+    backgroundColorBack,
+  } = useEditorStore.getState();
+  const isHorizontal = sideBarStore.getState().isHorizontal;
+
+  return {
+    title: title || '제목 없음',
+    status: 'draft',
+    content: {
+      backgroundColor,
+      canvasElements,
+      canvasBackElements,
+      backgroundColorBack,
+    } as unknown as Json,
+    slug,
+    frontImgURL: urls.front,
+    backImgURL: urls.back,
+    isHorizontal,
+  };
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

-  close #281 

<br>

## 📝 작업 내용

- 편집하기로 들어왔을 시 새롭게 저장하는 게 아니라 기존 파일을 업데이트 하는 형식으로 변경했습니다
-

<br>

## 🖼 스크린샷

이미지

<br>

## 💬 리뷰 요구사항

> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 카드 데이터를 카드 ID로 조회하는 기능이 추가되었습니다.
    - 카드 정보를 업데이트할 수 있는 기능이 도입되었습니다.
    - 카드 업데이트를 위한 커스텀 훅이 추가되었습니다.
    - 카드 업데이트용 페이로드 생성 기능이 추가되었습니다.

- **버그 수정**
    - 카드 편집 시 쿼리 파라미터가 slug에서 cardId로 변경되어 보다 정확한 카드 식별이 가능해졌습니다.

- **리팩터**
    - 카드 저장 로직이 cardId 기반으로 개선되어 기존 카드 수정과 신규 카드 생성이 모두 지원됩니다.
    - 에디터 내 저장 버튼 동작이 사용자 로그인 여부를 명확히 확인하도록 개선되었습니다.

- **스타일/기타**
    - 일부 컴포넌트와 인터페이스 명칭이 명확하게 변경되었습니다.
    - 슬러그 입력 필드의 플레이스홀더와 중복 검사 로직이 현재 슬러그 상태를 반영하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->