### PR TITLE
[STYLE]#292 공유된 명함 페이지 마크업

### DIFF
--- a/src/app/[...slug]/page.client.tsx
+++ b/src/app/[...slug]/page.client.tsx
@@ -9,6 +9,7 @@ import { useInteractionTracker } from '@/hooks/use-interaction-tracker';
 import { authStore } from '@/store/auth.store';
 import { Cards } from '@/types/supabase.type';
 import { sweetComingSoonAlert } from '@/utils/common/sweet-coming-soon-alert';
+import clsx from 'clsx';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
@@ -115,9 +116,25 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
       </div>
 
       {/* 카드 영역 */}
-      <div className='mt-[52px] flex h-[calc(100vh-180px)] w-full items-center justify-center overflow-y-auto px-4 md:mt-[80px] md:h-[calc(100vh-200px)]'>
-        <div className='relative mx-auto mt-4 h-full w-full max-w-[calc(100%-32px)] md:max-w-[468px]'>
-          <div className='flex h-full justify-center overflow-y-auto'>
+      <div
+        className={clsx(
+          'mt-[52px] flex h-[calc(100vh-180px)] w-full items-center justify-center px-4 md:mt-[80px] md:h-auto',
+          !initialData.isHorizontal &&
+            'md:h-[calc(100vh-200px)] md:overflow-y-auto'
+        )}
+      >
+        <div
+          className={clsx(
+            'relative mx-auto mt-4 w-full max-w-[calc(100%-32px)] md:max-w-[468px]',
+            !initialData.isHorizontal && 'h-full'
+          )}
+        >
+          <div
+            className={clsx(
+              'flex justify-center',
+              !initialData.isHorizontal && 'h-full'
+            )}
+          >
             <FlipCard ref={flipCardRef} />
           </div>
         </div>

--- a/src/app/[...slug]/page.client.tsx
+++ b/src/app/[...slug]/page.client.tsx
@@ -115,16 +115,16 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
       </div>
 
       {/* 카드 영역 */}
-      <div className='flex h-full w-full items-center justify-center px-4 pt-[52px] md:h-auto md:pt-[80px]'>
-        <div className='relative mx-auto mt-4 w-full max-w-[calc(100%-32px)] md:max-w-[468px]'>
-          <div className='flex justify-center'>
+      <div className='mt-[52px] flex h-[calc(100vh-180px)] w-full items-center justify-center overflow-y-auto px-4 md:mt-[80px] md:h-[calc(100vh-200px)]'>
+        <div className='relative mx-auto mt-4 h-full w-full max-w-[calc(100%-32px)] md:max-w-[468px]'>
+          <div className='flex h-full justify-center overflow-y-auto'>
             <FlipCard ref={flipCardRef} />
           </div>
         </div>
       </div>
 
       {/* 하단 버튼 영역 */}
-      <div className='flex w-full items-center justify-center gap-[11px] p-[16px] md:mt-9 md:w-auto md:gap-5 md:bg-transparent md:p-0 md:shadow-none'>
+      <div className='mb-4 flex w-full items-center justify-center gap-[11px] p-[16px] md:mt-9 md:w-auto md:gap-5 md:bg-transparent md:p-0 md:shadow-none'>
         <button
           onClick={handleImageSave}
           className='flex h-[46px] flex-1 items-center justify-center rounded-[6px] border border-solid border-gray-10 bg-white px-4 py-[6px] text-label2-medium shadow-[0px_4px_10px_0px_rgba(0,0,0,0.10)] md:flex-none md:rounded-[46px] md:px-[46px]'

--- a/src/app/[...slug]/page.client.tsx
+++ b/src/app/[...slug]/page.client.tsx
@@ -111,7 +111,8 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
         <h2 className='max-w-[80%] truncate md:max-w-full'>{pageTitle}</h2>
       </div>
 
-      <div className='flex w-full items-center justify-center'>
+      {/* TODO: 반응형 처리 필요 */}
+      <div className='flex w-full items-center justify-center overflow-y-auto'>
         <FlipCard ref={flipCardRef} />
       </div>
 

--- a/src/app/[...slug]/page.client.tsx
+++ b/src/app/[...slug]/page.client.tsx
@@ -97,29 +97,37 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
   const pageTitle = `${initialData.users?.nick_name || ''}님의 ${initialData?.title || ''} 명함`;
 
   return (
-    <div className='relative mx-auto flex h-[calc(100vh-64px)] max-w-5xl flex-col items-center justify-center border-b border-solid border-gray-10 bg-bg'>
-      <div className='absolute left-0 top-0 flex h-[52px] w-full items-center justify-center bg-white px-[20px] py-[14px] text-label1-semi md:h-[80px] md:justify-start md:px-[22px] md:py-5 md:text-title-bold'>
-        {initialData.user_id === userId && (
-          <Link
-            href={`${ROUTES.MYCARD}/${initialData.id}`}
-            className='absolute left-[20px] cursor-pointer md:static md:mr-[14px]'
-            aria-label='내 명함상세로 이동하기'
-          >
-            <LeftArrow size={isMobile ? 24 : 32} />
-          </Link>
-        )}
-        <h2 className='max-w-[80%] truncate md:max-w-full'>{pageTitle}</h2>
+    <div className='relative mx-auto flex h-[calc(100vh-64px)] max-w-5xl flex-col items-center justify-between overflow-x-hidden border-b border-solid border-gray-10 bg-bg md:justify-center'>
+      {/* 헤더 영역 */}
+      <div className='absolute left-0 top-0 z-50 flex h-[52px] w-full items-center justify-center border-b border-gray-10 bg-white shadow-sm md:h-[80px]'>
+        <div className='relative flex h-full w-full items-center justify-center px-[20px] py-[14px] text-label1-semi md:justify-start md:px-[22px] md:py-5 md:text-title-bold'>
+          {initialData.user_id === userId && (
+            <Link
+              href={`${ROUTES.MYCARD}/${initialData.id}`}
+              className='absolute left-[20px] cursor-pointer md:static md:mr-[14px]'
+              aria-label='내 명함상세로 이동하기'
+            >
+              <LeftArrow size={isMobile ? 24 : 32} />
+            </Link>
+          )}
+          <h2 className='max-w-[80%] truncate md:max-w-full'>{pageTitle}</h2>
+        </div>
       </div>
 
-      {/* TODO: 반응형 처리 필요 */}
-      <div className='flex w-full items-center justify-center overflow-y-auto'>
-        <FlipCard ref={flipCardRef} />
+      {/* 카드 영역 */}
+      <div className='flex h-full w-full items-center justify-center px-4 pt-[52px] md:h-auto md:pt-[80px]'>
+        <div className='relative mx-auto mt-4 w-full max-w-[calc(100%-32px)] md:max-w-[468px]'>
+          <div className='flex justify-center'>
+            <FlipCard ref={flipCardRef} />
+          </div>
+        </div>
       </div>
 
-      <div className='fixed bottom-[37px] left-0 flex w-full items-center justify-center gap-[11px] px-[16px] md:static md:bottom-auto md:left-auto md:mt-9 md:w-auto md:gap-5 md:px-0'>
+      {/* 하단 버튼 영역 */}
+      <div className='flex w-full items-center justify-center gap-[11px] p-[16px] md:mt-9 md:w-auto md:gap-5 md:bg-transparent md:p-0 md:shadow-none'>
         <button
           onClick={handleImageSave}
-          className='flex h-[46px] flex-1 items-center justify-center rounded-[6px] border border-solid border-gray-10 px-4 py-[6px] text-label2-medium shadow-[0px_4px_10px_0px_rgba(0,0,0,0.10)] md:flex-none md:rounded-[46px] md:px-[46px]'
+          className='flex h-[46px] flex-1 items-center justify-center rounded-[6px] border border-solid border-gray-10 bg-white px-4 py-[6px] text-label2-medium shadow-[0px_4px_10px_0px_rgba(0,0,0,0.10)] md:flex-none md:rounded-[46px] md:px-[46px]'
         >
           이미지 저장
         </button>

--- a/src/app/[...slug]/page.client.tsx
+++ b/src/app/[...slug]/page.client.tsx
@@ -115,7 +115,7 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
         <FlipCard ref={flipCardRef} />
       </div>
 
-      <div className='fixed bottom-[37px] left-0 flex w-full items-center justify-center gap-[11px] px-[12px] pr-[37px] md:static md:bottom-auto md:left-auto md:mt-9 md:w-auto md:gap-5 md:px-0'>
+      <div className='fixed bottom-[37px] left-0 flex w-full items-center justify-center gap-[11px] px-[16px] md:static md:bottom-auto md:left-auto md:mt-9 md:w-auto md:gap-5 md:px-0'>
         <button
           onClick={handleImageSave}
           className='flex h-[46px] flex-1 items-center justify-center rounded-[6px] border border-solid border-gray-10 px-4 py-[6px] text-label2-medium shadow-[0px_4px_10px_0px_rgba(0,0,0,0.10)] md:flex-none md:rounded-[46px] md:px-[46px]'

--- a/src/app/[...slug]/page.client.tsx
+++ b/src/app/[...slug]/page.client.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import FlipCard, { FlipCardRef } from '@/components/card/flip-card';
+import LeftArrow from '@/components/icons/left-arrow';
+import { ROUTES } from '@/constants/path.constant';
 import { useLogInteractionMutation } from '@/hooks/mutations/use-init-session';
 import { useIpAddressQuery } from '@/hooks/queries/use-ip-address';
 import { useInteractionTracker } from '@/hooks/use-interaction-tracker';
+import { authStore } from '@/store/auth.store';
 import { Cards } from '@/types/supabase.type';
 import { sweetComingSoonAlert } from '@/utils/common/sweet-coming-soon-alert';
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface SlugClientPageParams {
   initialData: Cards & {
@@ -24,9 +28,27 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
   const allowedSources = ['direct', 'qr', 'link', 'tag'] as const;
   const source =
     allowedSources.find((s) => params.get('source')?.includes(s)) || 'direct';
+  const userId = authStore((state) => state.userId);
 
   const id = initialData?.id || '';
   const slug = initialData.slug;
+
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkScreenSize = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    // 초기 실행
+    checkScreenSize();
+
+    // 리사이즈 이벤트 리스너 추가
+    window.addEventListener('resize', checkScreenSize);
+
+    // 클린업
+    return () => window.removeEventListener('resize', checkScreenSize);
+  }, []);
 
   const { handleSaveImg, updateActivity, handleSaveVCard } =
     useInteractionTracker({
@@ -76,24 +98,33 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
 
   return (
     <div className='relative mx-auto flex h-[calc(100vh-64px)] max-w-5xl flex-col items-center justify-center border-b border-solid border-gray-10 bg-bg'>
-      <div className='absolute left-0 top-0 flex h-[80px] w-full items-center justify-start bg-white px-8 py-5 text-title-bold'>
-        <h2>{pageTitle}</h2>
+      <div className='absolute left-0 top-0 flex h-[52px] w-full items-center justify-center bg-white px-[20px] py-[14px] text-label1-semi md:h-[80px] md:justify-start md:px-[22px] md:py-5 md:text-title-bold'>
+        {initialData.user_id === userId && (
+          <Link
+            href={`${ROUTES.MYCARD}/${initialData.id}`}
+            className='absolute left-[20px] cursor-pointer md:static md:mr-[14px]'
+            aria-label='내 명함상세로 이동하기'
+          >
+            <LeftArrow size={isMobile ? 24 : 32} />
+          </Link>
+        )}
+        <h2 className='max-w-[80%] truncate md:max-w-full'>{pageTitle}</h2>
       </div>
 
-      <div className='flex w-[50%] items-center justify-center'>
+      <div className='flex w-full items-center justify-center'>
         <FlipCard ref={flipCardRef} />
       </div>
 
-      <div className='mt-9 flex items-center justify-center gap-4'>
+      <div className='fixed bottom-[37px] left-0 flex w-full items-center justify-center gap-[11px] px-[12px] pr-[37px] md:static md:bottom-auto md:left-auto md:mt-9 md:w-auto md:gap-5 md:px-0'>
         <button
           onClick={handleImageSave}
-          className='flex h-[46px] items-center justify-center rounded-[46px] border border-solid border-gray-10 px-[46px] py-[6px] text-label2-medium shadow-[0px_4px_40px_0px_rgba(0,0,0,0.15)]'
+          className='flex h-[46px] flex-1 items-center justify-center rounded-[6px] border border-solid border-gray-10 px-4 py-[6px] text-label2-medium shadow-[0px_4px_10px_0px_rgba(0,0,0,0.10)] md:flex-none md:rounded-[46px] md:px-[46px]'
         >
           이미지 저장
         </button>
         <button
           onClick={sweetComingSoonAlert}
-          className='flex h-[46px] items-center justify-center rounded-[46px] bg-primary-40 px-[46px] py-[6px] text-label2-medium text-white shadow-[0px_4px_40px_0px_rgba(0,0,0,0.15)]'
+          className='flex h-[46px] flex-1 items-center justify-center rounded-[6px] bg-primary-40 px-4 py-[6px] text-label2-medium text-white shadow-[0px_4px_10px_0px_rgba(0,0,0,0.10)] md:flex-none md:rounded-full md:px-[46px]'
         >
           연락처 저장
         </button>

--- a/src/components/card/card-skeleton.tsx
+++ b/src/components/card/card-skeleton.tsx
@@ -1,26 +1,47 @@
 import clsx from 'clsx';
 import FlipArrow from '../icons/flip-arrow';
+import { useEffect, useState } from 'react';
 
 interface CardSkeletonProps {
   isDetail?: boolean;
 }
 
 const CardSkeleton = ({ isDetail }: CardSkeletonProps) => {
-  const CARD_DEFAULT_STYLE =
-    'bg-slate-700 absolute flex justify-center items-center backface-hidden w-full shadow-[37px_108px_32px_0px_rgba(0,0,0,0.00),24px_69px_29px_0px_rgba(0,0,0,0.01),13px_39px_25px_0px_rgba(0,0,0,0.05),6px_17px_18px_0px_rgba(0,0,0,0.09),1px_4px_10px_0px_rgba(0,0,0,0.10)] aspect-[9/5]';
-  const CARD_DEFAULT_WRAPPER_STYLE =
-    'relative transition-transform duration-1000 cursor-pointer transform-style-preserve-3d';
-  const CARD_DEFAULT_BUTTON_STYLE = 'z-10 h-[34px] w-[34px] cursor-pointer';
-  const CARD_DEFAULT_BUTTON_STYLE_ATTACHED = 'absolute bottom-[-18px]';
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    // 클라이언트 사이드에서만 실행되도록 함
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    // 초기 실행
+    checkMobile();
+
+    // 리사이즈 이벤트 리스너 추가
+    window.addEventListener('resize', checkMobile);
+
+    // 클린업
+    return () => {
+      window.removeEventListener('resize', checkMobile);
+    };
+  }, []);
 
   return (
-    <div className='relative mb-11 flex w-full flex-col items-center justify-center'>
-      <div className='m-5 aspect-[9/5] w-full perspective-1000'>
-        <div className={CARD_DEFAULT_WRAPPER_STYLE}>
-          <div
-            className={clsx(CARD_DEFAULT_STYLE, 'animate-pulse bg-gray-200')}
-          >
-            <div className='flex h-full w-full flex-col items-center justify-center gap-4'>
+    <div className='relative mx-[25px] mb-[66px] flex w-full flex-col items-center justify-center md:w-auto'>
+      <div
+        className={clsx(
+          'relative perspective-1000',
+          isDetail
+            ? 'h-[150px] w-[270px]'
+            : isMobile
+              ? 'aspect-[9/5] w-full'
+              : 'h-[244px] w-[468px]'
+        )}
+      >
+        <div className='relative flex h-full w-full justify-center transform-style-preserve-3d'>
+          <div className='absolute flex h-full w-full items-center justify-center rounded-md bg-gray-200 shadow-md'>
+            <div className='flex h-full w-full flex-col items-center justify-center gap-4 p-4'>
               <div className='h-6 w-1/2 animate-pulse rounded-md bg-gray-300'></div>
               <div className='h-4 w-1/3 animate-pulse rounded-md bg-gray-300'></div>
               <div className='h-4 w-2/3 animate-pulse rounded-md bg-gray-300'></div>
@@ -28,11 +49,11 @@ const CardSkeleton = ({ isDetail }: CardSkeletonProps) => {
           </div>
         </div>
       </div>
+
       <div
         className={clsx(
-          CARD_DEFAULT_BUTTON_STYLE,
-          isDetail && CARD_DEFAULT_BUTTON_STYLE_ATTACHED,
-          'opacity-50'
+          'z-10 h-[40px] w-[40px] cursor-pointer opacity-50',
+          isDetail ? 'absolute bottom-[-36px]' : 'absolute bottom-[-54px]'
         )}
       >
         <FlipArrow />

--- a/src/components/card/flip-card.tsx
+++ b/src/components/card/flip-card.tsx
@@ -65,9 +65,9 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
 
   // 모바일 기기 감지
   useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth <= 768);
-    };
+    const mq = window.matchMedia('(max-width: 768px)');
+    const checkMobile = () => setIsMobile(mq.matches);
+    mq.addEventListener?.('change', checkMobile);
 
     // 초기 체크 및 이벤트 리스너 등록
     checkMobile();

--- a/src/components/card/flip-card.tsx
+++ b/src/components/card/flip-card.tsx
@@ -153,7 +153,7 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
     if (isMobile) {
       return data.isHorizontal
         ? { width: 'w-full', height: 'aspect-[9/5]' }
-        : { width: 'w-full', height: 'aspect-[5/9]' };
+        : { width: 'w-[200px]', height: 'h-[360px]' };
     }
 
     // 데스크톱인 경우

--- a/src/components/card/flip-card.tsx
+++ b/src/components/card/flip-card.tsx
@@ -36,6 +36,7 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
   const [size, setSize] = useState({ width: 0, height: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // 외부에서 호출 가능한 메서드 정의
   useImperativeHandle(ref, () => ({
     exportCardImages: async () => {
       try {
@@ -57,74 +58,52 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
     },
   }));
 
-  const CARD_WRAPPER_STYLE =
-    'relative mx-[25px] mb-[66px] flex w-full flex-col items-center justify-center md:w-auto';
-  const CARD_DEFAULT_STYLE =
-    'absolute flex justify-center items-center backface-hidden shadow-[37px_108px_32px_0px_rgba(0,0,0,0.00),24px_69px_29px_0px_rgba(0,0,0,0.01),13px_39px_25px_0px_rgba(0,0,0,0.05),6px_17px_18px_0px_rgba(0,0,0,0.09),1px_4px_10px_0px_rgba(0,0,0,0.10)] w-full h-full md:w-auto md:h-auto';
-  const CARD_DEFAULT_WRAPPER_STYLE =
-    'flex justify-center relative transition-transform duration-1000 cursor-pointer transform-style-preserve-3d w-full h-full md:w-auto md:h-auto';
-  const CARD_DEFAULT_BUTTON_STYLE = 'z-10 h-[40px] w-[40px] cursor-pointer';
-
+  // 추적 세션 초기화
   useEffect(() => {
     setStartedAt(new Date());
   }, []);
 
+  // 모바일 기기 감지
   useEffect(() => {
-    // 클라이언트 사이드에서만 실행되도록 함
     const checkMobile = () => {
       setIsMobile(window.innerWidth <= 768);
     };
 
-    // 초기 체크
+    // 초기 체크 및 이벤트 리스너 등록
     checkMobile();
-
-    // 리사이즈 이벤트 리스너 추가
     window.addEventListener('resize', checkMobile);
 
-    // 클린업
-    return () => {
-      window.removeEventListener('resize', checkMobile);
-    };
+    return () => window.removeEventListener('resize', checkMobile);
   }, []);
 
+  // 모바일에서 카드 크기 조정 처리
   useEffect(() => {
-    const handleResize = () => {
-      if (isMobile && containerRef.current) {
-        const observer = new ResizeObserver((entries) => {
-          for (let entry of entries) {
-            const { width, height } = entry.contentRect;
-            setSize({ width, height });
-          }
-        });
-        observer.observe(containerRef.current);
+    if (!isMobile || !containerRef.current) {
+      setSize({ width: 0, height: 0 });
+      return;
+    }
 
-        return () => {
-          observer.disconnect();
-        };
-      } else {
-        setSize({ width: 0, height: 0 });
+    const observer = new ResizeObserver((entries) => {
+      for (let entry of entries) {
+        const { width, height } = entry.contentRect;
+        setSize({ width, height });
       }
-    };
-    handleResize();
+    });
 
-    const resizeListener = () => {
-      handleResize();
-    };
-
-    window.addEventListener('resize', resizeListener);
-
-    return () => {
-      window.removeEventListener('resize', resizeListener);
-    };
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
   }, [isMobile]);
 
+  // 카드 데이터 가져오기
   const pathname = usePathname();
   const pathArray = pathname.split('/')[1];
   const cardId = pathname.split('/')[2];
+
   const { data: slug } = useCardSlug(cardId, {
     enabled: isDetail,
   });
 
+  // 소스 파라미터 처리
   const searchParams = useSearchParams();
   const source = (() => {
     const param = searchParams.get('source');
@@ -139,12 +118,14 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
     return null;
   })();
 
+  // 인터랙션 트래커 설정
   const { handleClick } = useInteractionTracker({
     slug: isDetail ? slug || '' : pathArray,
     source,
     startedAt,
   });
 
+  // 카드 콘텐츠 가져오기
   const { data, isPending, error } = useCardContent(
     isDetail ? slug || '' : pathArray
   );
@@ -159,104 +140,106 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
     return <ErrorCard isDetail={!!isDetail} error={error} />;
   }
 
+  // 카드 크기 계산
+  const getCardDimensions = () => {
+    // 카드가 자세히 보기 모드인 경우
+    if (isDetail) {
+      return data.isHorizontal
+        ? { width: 'w-[270px]', height: 'h-[150px]' }
+        : { width: 'w-[150px]', height: 'h-[270px]' };
+    }
+
+    // 모바일인 경우
+    if (isMobile) {
+      return data.isHorizontal
+        ? { width: 'w-full', height: 'aspect-[9/5]' }
+        : { width: 'w-full', height: 'aspect-[5/9]' };
+    }
+
+    // 데스크톱인 경우
+    return data.isHorizontal
+      ? { width: 'w-[468px]', height: 'h-[244px]' }
+      : { width: 'w-[244px]', height: 'h-[468px]' };
+  };
+
+  const { width, height } = getCardDimensions();
+
+  // 카드 이미지 렌더링
+  const renderCardFace = (isFront: boolean) => {
+    if (isDetail) {
+      return (
+        <Image
+          src={isFront ? data.frontImgURL || '' : data.backImgURL || ''}
+          alt={`${data.title} 명함 ${isFront ? '앞면' : '뒷면'}`}
+          width={data.isHorizontal ? 270 : 150}
+          height={data.isHorizontal ? 150 : 270}
+        />
+      );
+    }
+
+    return (
+      <CardStageViewer
+        ref={isFront ? frontCardRef : backCardRef}
+        isHorizontal={data.isHorizontal}
+        elements={
+          isFront
+            ? data.content?.canvasElements || []
+            : data.content?.canvasBackElements || []
+        }
+        backgroundColor={
+          isFront
+            ? data.content?.backgroundColor || '#ffffff'
+            : data.content?.backgroundColorBack || '#ffffff'
+        }
+        previewMode={true}
+        onSocialClick={handleClick}
+        size={size}
+      />
+    );
+  };
+
+  // 버튼 위치 계산
+  const buttonPosition =
+    isDetail && data.isHorizontal
+      ? 'absolute bottom-[-36px]'
+      : 'absolute bottom-[-54px]';
+
   return (
-    <div className={CARD_WRAPPER_STYLE}>
-      <div
-        className={clsx(
-          'relative perspective-1000',
-          isDetail
-            ? data.isHorizontal
-              ? 'h-[150px] w-[270px]'
-              : 'h-[270px] w-[150px]'
-            : isMobile
-              ? data.isHorizontal
-                ? 'aspect-[9/5] w-full'
-                : 'aspect-[5/9] w-full'
-              : data.isHorizontal
-                ? 'h-[244px] w-[468px]'
-                : 'h-[468px] w-[244px]'
-        )}
-      >
+    <div className='relative mx-[25px] mb-[66px] flex w-full flex-col items-center justify-center md:w-auto'>
+      <div className={clsx('relative perspective-1000', width, height)}>
         <div
-          className={clsx(
-            CARD_DEFAULT_WRAPPER_STYLE,
-            isFlipped && 'rotate-y-180',
-            isDetail
-              ? data.isHorizontal
-                ? 'h-[150px] w-[270px]'
-                : 'h-[270px] w-[150px]'
-              : isMobile
-                ? data.isHorizontal
-                  ? 'aspect-[9/5] w-full'
-                  : 'aspect-[5/9] w-full'
-                : data.isHorizontal
-                  ? 'h-[244px] w-[468px]'
-                  : 'h-[468px] w-[244px]'
-          )}
           ref={containerRef}
+          className={clsx(
+            'relative flex justify-center transition-transform duration-1000 transform-style-preserve-3d',
+            isFlipped && 'rotate-y-180',
+            width,
+            height
+          )}
         >
+          {/* 앞면 */}
           <div
-            className={CARD_DEFAULT_STYLE}
-            style={{
-              pointerEvents: 'auto',
-              cursor: 'default',
-            }}
+            className='absolute flex h-full w-full items-center justify-center shadow-[37px_108px_32px_0px_rgba(0,0,0,0.00),24px_69px_29px_0px_rgba(0,0,0,0.01),13px_39px_25px_0px_rgba(0,0,0,0.05),6px_17px_18px_0px_rgba(0,0,0,0.09),1px_4px_10px_0px_rgba(0,0,0,0.10)] backface-hidden md:h-auto md:w-auto'
+            style={{ pointerEvents: 'auto', cursor: 'default' }}
           >
-            {isDetail ? (
-              <Image
-                src={data.frontImgURL || ''}
-                alt={`${data.title} 명함`}
-                width={data.isHorizontal ? 270 : 150}
-                height={data.isHorizontal ? 150 : 270}
-              />
-            ) : (
-              <CardStageViewer
-                ref={frontCardRef}
-                isHorizontal={data.isHorizontal}
-                elements={data.content?.canvasElements || []}
-                backgroundColor={data.content?.backgroundColor || '#ffffff'}
-                previewMode={true}
-                onSocialClick={handleClick}
-                size={size}
-              />
-            )}
+            {renderCardFace(true)}
           </div>
+
+          {/* 뒷면 */}
           <div
-            className={clsx(CARD_DEFAULT_STYLE, 'rotate-y-180')}
-            style={{
-              pointerEvents: 'auto',
-              cursor: 'default',
-            }}
+            className='absolute flex h-full w-full items-center justify-center shadow-[37px_108px_32px_0px_rgba(0,0,0,0.00),24px_69px_29px_0px_rgba(0,0,0,0.01),13px_39px_25px_0px_rgba(0,0,0,0.05),6px_17px_18px_0px_rgba(0,0,0,0.09),1px_4px_10px_0px_rgba(0,0,0,0.10)] backface-hidden rotate-y-180 md:h-auto md:w-auto'
+            style={{ pointerEvents: 'auto', cursor: 'default' }}
           >
-            {isDetail ? (
-              <Image
-                src={data.backImgURL || ''}
-                alt={`${data.title} 명함`}
-                width={data.isHorizontal ? 270 : 150}
-                height={data.isHorizontal ? 150 : 270}
-              />
-            ) : (
-              <CardStageViewer
-                ref={backCardRef}
-                isHorizontal={data.isHorizontal}
-                elements={data.content?.canvasBackElements || []}
-                backgroundColor={data.content?.backgroundColorBack || '#ffffff'}
-                previewMode={true}
-                onSocialClick={handleClick}
-                size={size}
-              />
-            )}
+            {renderCardFace(false)}
           </div>
         </div>
       </div>
 
+      {/* 뒤집기 버튼 */}
       <div
-        onClick={() => setIsFlipped((pre: boolean) => !pre)}
+        onClick={() => setIsFlipped((prev) => !prev)}
         className={clsx(
-          CARD_DEFAULT_BUTTON_STYLE,
-          isDetail && data.isHorizontal
-            ? 'absolute bottom-[-36px]'
-            : 'absolute bottom-[-54px]'
+          'z-10 h-[40px] w-[40px] cursor-pointer',
+          buttonPosition
         )}
       >
         <FlipArrow />

--- a/src/components/card/flip-card.tsx
+++ b/src/components/card/flip-card.tsx
@@ -206,7 +206,9 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
 
   return (
     <div className='relative mx-[25px] mb-[66px] flex w-full flex-col items-center justify-center md:w-auto'>
-      <div className={clsx('relative perspective-1000', width, height)}>
+      <div
+        className={clsx('relative py-[20px] perspective-1000', width, height)}
+      >
         <div
           ref={containerRef}
           className={clsx(
@@ -218,7 +220,7 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
         >
           {/* 앞면 */}
           <div
-            className='absolute flex h-full w-full items-center justify-center shadow-[37px_108px_32px_0px_rgba(0,0,0,0.00),24px_69px_29px_0px_rgba(0,0,0,0.01),13px_39px_25px_0px_rgba(0,0,0,0.05),6px_17px_18px_0px_rgba(0,0,0,0.09),1px_4px_10px_0px_rgba(0,0,0,0.10)] backface-hidden md:h-auto md:w-auto'
+            className='absolute flex h-full w-full items-center justify-center shadow-[20px_60px_20px_0px_rgba(0,0,0,0.00),12px_40px_15px_0px_rgba(0,0,0,0.01),7px_20px_12px_0px_rgba(0,0,0,0.05),3px_10px_10px_0px_rgba(0,0,0,0.09),1px_3px_5px_0px_rgba(0,0,0,0.10)] backface-hidden md:h-auto md:w-auto'
             style={{ pointerEvents: 'auto', cursor: 'default' }}
           >
             {renderCardFace(true)}
@@ -226,7 +228,7 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
 
           {/* 뒷면 */}
           <div
-            className='absolute flex h-full w-full items-center justify-center shadow-[37px_108px_32px_0px_rgba(0,0,0,0.00),24px_69px_29px_0px_rgba(0,0,0,0.01),13px_39px_25px_0px_rgba(0,0,0,0.05),6px_17px_18px_0px_rgba(0,0,0,0.09),1px_4px_10px_0px_rgba(0,0,0,0.10)] backface-hidden rotate-y-180 md:h-auto md:w-auto'
+            className='absolute flex h-full w-full items-center justify-center shadow-[20px_60px_20px_0px_rgba(0,0,0,0.00),12px_40px_15px_0px_rgba(0,0,0,0.01),7px_20px_12px_0px_rgba(0,0,0,0.05),3px_10px_10px_0px_rgba(0,0,0,0.09),1px_3px_5px_0px_rgba(0,0,0,0.10)] backface-hidden rotate-y-180 md:h-auto md:w-auto'
             style={{ pointerEvents: 'auto', cursor: 'default' }}
           >
             {renderCardFace(false)}

--- a/src/components/card/flip-card.tsx
+++ b/src/components/card/flip-card.tsx
@@ -206,9 +206,7 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
 
   return (
     <div className='relative mx-[25px] mb-[66px] flex w-full flex-col items-center justify-center md:w-auto'>
-      <div
-        className={clsx('relative py-[20px] perspective-1000', width, height)}
-      >
+      <div className={clsx('relative perspective-1000', width, height)}>
         <div
           ref={containerRef}
           className={clsx(
@@ -237,15 +235,17 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
       </div>
 
       {/* 뒤집기 버튼 */}
-      <div
+      <button
+        type='button'
+        aria-label='명함 뒤집기'
         onClick={() => setIsFlipped((prev) => !prev)}
         className={clsx(
-          'z-10 h-[40px] w-[40px] cursor-pointer',
+          'z-10 h-[40px] w-[40px] cursor-pointer focus:outline-none focus:ring',
           buttonPosition
         )}
       >
         <FlipArrow />
-      </div>
+      </button>
     </div>
   );
 });

--- a/src/components/card/konva-stage-viewer.tsx
+++ b/src/components/card/konva-stage-viewer.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { Stage, Layer, Rect } from 'react-konva';
-import { ElEMENT_TYPE } from '@/constants/editor.constant';
+import {
+  BASE_STAGE_HEIGHT,
+  BASE_STAGE_WIDTH,
+  ElEMENT_TYPE,
+} from '@/constants/editor.constant';
 import {
   CanvasElements,
   QrElement,
@@ -30,6 +34,10 @@ interface CardStageViewerProps {
   elements: CanvasElements[];
   backgroundColor: string;
   previewMode?: boolean;
+  size: {
+    width: number;
+    height: number;
+  };
   onSocialClick?: ({
     url,
     elementName,
@@ -41,12 +49,16 @@ interface CardStageViewerProps {
 
 const CardStageViewer = forwardRef<CardStageViewerRef, CardStageViewerProps>(
   (
-    { isHorizontal, elements, backgroundColor, previewMode, onSocialClick },
+    {
+      isHorizontal,
+      elements,
+      backgroundColor,
+      previewMode,
+      onSocialClick,
+      size,
+    },
     ref
   ) => {
-    const WIDTH = isHorizontal ? 468 : 244;
-    const HEIGHT = isHorizontal ? 244 : 468;
-
     const stageRef = useRef<Konva.Stage>(null);
 
     // 외부에서 호출할 수 있는 메서드 노출
@@ -66,19 +78,30 @@ const CardStageViewer = forwardRef<CardStageViewerRef, CardStageViewerProps>(
         return dataURLtoBlob(dataURL);
       },
     }));
+
+    const stageWidth = BASE_STAGE_WIDTH;
+    const stageHeight = BASE_STAGE_HEIGHT;
+
+    const currentStageWidth = isHorizontal ? stageWidth : stageHeight;
+    const currentStageHeight = isHorizontal ? stageHeight : stageWidth;
+
     return (
       <Stage
-        ref={stageRef}
-        width={WIDTH}
-        height={HEIGHT}
-        style={{ pointerEvents: 'auto' }}
+        width={size.width !== 0 ? size.width : stageWidth}
+        height={size.height !== 0 ? size.height : stageHeight}
+        scale={{
+          x: (size.width !== 0 ? size.width : stageWidth) / currentStageWidth,
+          y:
+            (size.height !== 0 ? size.height : stageHeight) /
+            currentStageHeight,
+        }}
       >
         <Layer>
           <Rect
             x={0}
             y={0}
-            width={WIDTH}
-            height={HEIGHT}
+            width={size.width !== 0 ? size.width : stageWidth}
+            height={size.height !== 0 ? size.height : stageHeight}
             fill={backgroundColor}
             listening={false}
           />

--- a/src/components/card/konva-stage-viewer.tsx
+++ b/src/components/card/konva-stage-viewer.tsx
@@ -87,12 +87,14 @@ const CardStageViewer = forwardRef<CardStageViewerRef, CardStageViewerProps>(
 
     return (
       <Stage
-        width={size.width !== 0 ? size.width : stageWidth}
-        height={size.height !== 0 ? size.height : stageHeight}
+        width={size.width !== 0 ? size.width : currentStageWidth}
+        height={size.height !== 0 ? size.height : currentStageHeight}
         scale={{
-          x: (size.width !== 0 ? size.width : stageWidth) / currentStageWidth,
+          x:
+            (size.width !== 0 ? size.width : currentStageWidth) /
+            currentStageWidth,
           y:
-            (size.height !== 0 ? size.height : stageHeight) /
+            (size.height !== 0 ? size.height : currentStageHeight) /
             currentStageHeight,
         }}
       >
@@ -100,10 +102,18 @@ const CardStageViewer = forwardRef<CardStageViewerRef, CardStageViewerProps>(
           <Rect
             x={0}
             y={0}
-            width={size.width !== 0 ? size.width : stageWidth}
-            height={size.height !== 0 ? size.height : stageHeight}
+            width={size.width !== 0 ? size.width : currentStageWidth}
+            height={size.height !== 0 ? size.height : currentStageHeight}
             fill={backgroundColor}
             listening={false}
+            scale={{
+              x:
+                (size.width !== 0 ? size.width : currentStageWidth) /
+                currentStageWidth,
+              y:
+                (size.height !== 0 ? size.height : currentStageHeight) /
+                currentStageHeight,
+            }}
           />
           {elements.map((el) => (
             <SwitchCase

--- a/src/components/icons/left-arrow.tsx
+++ b/src/components/icons/left-arrow.tsx
@@ -1,21 +1,31 @@
 import { SVGProps } from 'react';
 
-const LeftArrow = (props: SVGProps<SVGSVGElement>) => (
-  <svg
-    xmlns='http://www.w3.org/2000/svg'
-    className='h-5 w-5'
-    fill='none'
-    viewBox='0 0 24 24'
-    stroke='currentColor'
-    {...props}
-  >
-    <path
-      strokeLinecap='round'
-      strokeLinejoin='round'
-      strokeWidth={2}
-      d='M15 19l-7-7 7-7'
-    />
-  </svg>
-);
+interface LeftArrowProps {
+  size?: number;
+}
+
+const LeftArrow = ({
+  size = 32,
+  ...props
+}: LeftArrowProps & SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox='3.67 4 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      {...props}
+    >
+      <g id='tdesign:chevron-left'>
+        <path
+          id='Vector'
+          d='M21.2187 23.3333L13.8854 15.9999L21.2187 8.66658L19.3334 6.78125L10.1147 15.9999L19.3334 25.2186L21.2187 23.3333Z'
+          fill={props.fill || 'currentColor'}
+        />
+      </g>
+    </svg>
+  );
+};
 
 export default LeftArrow;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #292

<br>

## 📝 작업 내용

- 명함 에디터 반응형 사이즈 적용
- 내 명함의 공유된 페이지 일 경우 뒤로가기 아이콘 추가
- 공유된 명함 페이지 마크업

<br>

## 🖼 스크린샷

내 명함의 공유된 명함 페이지 일 경우 (좌측 화살표 추가)


https://github.com/user-attachments/assets/efc5ceda-ef59-4b21-a681-b8dd0a162c36


내 명함의 공유된 명함 페이지가 아닐때 (좌측 화살표 없음)
![스크린샷 2025-04-25 오전 12 34 05](https://github.com/user-attachments/assets/189e70be-1a84-432c-a0ee-6b8a3155720e)



https://github.com/user-attachments/assets/99fff79f-7305-403f-b462-634ba15a0d10



<br>

## 💬 리뷰 요구사항

> 반응형시 배경 부분도 일정 영역이 되면 같이 줄어들더라구요.. 이 부분은 추후 수정토록 하겠습니다...ㅠ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 카드 상세 페이지 및 카드 스켈레톤, 플립 카드에 모바일 환경 대응(반응형) 기능이 추가되어 다양한 화면 크기에서 최적화된 레이아웃을 제공합니다.
- **스타일**
	- 카드 및 버튼, 헤더, 아이콘 등의 스타일이 모바일 및 데스크톱 환경에 맞게 개선되었습니다.
- **리팩터**
	- 카드 컴포넌트 구조와 렌더링 로직이 더 깔끔하고 유지보수하기 쉽게 개선되었습니다.
- **버그 수정**
	- 버튼 위치와 카드 크기 등이 모바일 환경에서 올바르게 표시되도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->