### PR TITLE
[BUGFIX]#300 에디터에서 제목 수정시 내명함페이지 미반영 버그 수정

### DIFF
--- a/src/app/dashboard/my-cards/page.tsx
+++ b/src/app/dashboard/my-cards/page.tsx
@@ -7,26 +7,18 @@ import { createClient } from '@/utils/supabase/server';
 const MyCardsPage = async () => {
   const supabase = await createClient();
 
-  // 현재 세션 정보를 받아옴
+  // 유저 정보 조회
   const {
-    data: { session },
-    error: sessionError,
-  } = await supabase.auth.getSession();
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
 
-  if (sessionError) {
-    console.error('세션 정보를 가져오는 중 에러 발생:', sessionError);
+  if (error || !user) {
+    console.error('유저 정보를 가져오는 중 에러 발생:', error);
+    throw new Error('유저 정보를 불러올 수 없습니다.');
   }
 
-  // 로그인하지 않은 경우 처리
-  if (!session?.user?.id) {
-    return (
-      <div className='flex h-screen items-center justify-center'>
-        <p className='text-lg'>로그인 후 이용 가능합니다.</p>
-      </div>
-    );
-  }
-
-  const userId = session.user.id;
+  const userId = user.id;
 
   return (
     <>

--- a/src/components/dashboard/card-item.tsx
+++ b/src/components/dashboard/card-item.tsx
@@ -22,6 +22,11 @@ const CardItem = ({ card }: CardItemProps) => {
   const nickName = authStore((state) => state.userName);
   const [origin, setOrigin] = useState<string>('');
 
+  // card.title prop이 바뀔 때마다 동기화
+  useEffect(() => {
+    setCardTitle(card.title);
+  }, [card.title]);
+
   useEffect(() => {
     if (typeof window !== 'undefined') setOrigin(window.location.origin);
   }, []);

--- a/src/components/dashboard/card-title-editor.tsx
+++ b/src/components/dashboard/card-title-editor.tsx
@@ -23,6 +23,11 @@ const CardTitleEditor = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
 
+  // initialTitle prop 이 바뀔 때마다 title state 동기화
+  useEffect(() => {
+    setTitle(initialTitle);
+  }, [initialTitle]);
+
   // 편집 모드가 활성화되면 인풋에 포커스
   useEffect(() => {
     if (isEditing) {
@@ -55,7 +60,9 @@ const CardTitleEditor = ({
 
     try {
       const updatedCard = await updateCardTitle(cardId, title);
+      // 내부 state 도 즉시 최신값으로 덮어쓰기
       onUpdate(updatedCard.title);
+      setTitle(updatedCard.title);
       setIsEditing(false);
     } catch (error) {
       console.error('제목 업데이트 실패:', error);

--- a/src/hooks/use-slugged-save-card.ts
+++ b/src/hooks/use-slugged-save-card.ts
@@ -15,6 +15,7 @@ import { User, UserMetadata } from '@supabase/supabase-js';
 import { createCardUpdatePayload } from '@/utils/editor/save/create-card-update-payload';
 import { useCardUpdate } from '@/hooks/mutations/use-card-update';
 import { useQueryClient } from '@tanstack/react-query';
+import { QUERY_KEY } from '@/constants/query-key';
 
 export const useSluggedSaveCard = () => {
   const queryClient = useQueryClient();
@@ -70,9 +71,17 @@ export const useSluggedSaveCard = () => {
           {
             onSuccess: () => {
               queryClient.invalidateQueries({
-                queryKey: ['card', cardId],
-              });
-              sweetAlertUtil.success('수정 성공', '명함이 수정되었습니다.');
+                queryKey: [QUERY_KEY.CARD, cardId],
+              }),
+                // 리스트도 무효화 필요
+                queryClient.invalidateQueries({
+                  queryKey: [QUERY_KEY.CARD_LIST, userId],
+                }),
+                // 상세페이지 제목 무효화
+                queryClient.invalidateQueries({
+                  queryKey: [QUERY_KEY.CARD_SELECT_LIST, userId],
+                }),
+                sweetAlertUtil.success('수정 성공', '명함이 수정되었습니다.');
               resetEditorState();
               router.refresh();
               router.push(ROUTES.DASHBOARD.MYCARDS);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #300 

<br>

## 📝 작업 내용

- 기존 명함을 에디터에서 편집 후 내명함, 상세페이지에서 제목 수정 미반영 해결

<br>

## 🖼 스크린샷

https://github.com/user-attachments/assets/ca1347ed-2c04-4037-8ef4-da17837ce580

<br>

## 💬 리뷰 요구사항

> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
