### PR TITLE
[REFACTOR] : useCardSlug도 리패치 항상 하도록 #303

### DIFF
--- a/src/hooks/queries/use-card-slug.ts
+++ b/src/hooks/queries/use-card-slug.ts
@@ -13,6 +13,7 @@ const useCardSlug = (card_id: string, options?: { enabled?: boolean }) => {
     queryKey: [QUERY_KEY.CARD_SLUG, card_id],
     queryFn: async () => getSlugData(card_id),
     enabled: options?.enabled ?? !!card_id,
+    refetchOnMount: 'always',
   });
 };
 

--- a/src/hooks/use-slugged-save-card.ts
+++ b/src/hooks/use-slugged-save-card.ts
@@ -11,7 +11,7 @@ import { validateSlug } from '@/utils/editor/save/validate-slug';
 import { resetEditorState } from '@/utils/editor/editor-reset-state';
 import { createCardInsertPayload } from '@/utils/editor/save/create-card-insert-payload';
 import { getStageImageUrls } from '@/utils/editor/save/get-state-image-url';
-import { User, UserMetadata } from '@supabase/supabase-js';
+import { User } from '@supabase/supabase-js';
 import { createCardUpdatePayload } from '@/utils/editor/save/create-card-update-payload';
 import { useCardUpdate } from '@/hooks/mutations/use-card-update';
 import { useQueryClient } from '@tanstack/react-query';


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #303 

<br>

## 📝 작업 내용

- useCardSlug도 리패치 항상 하도록
-

<br>

## 🖼 스크린샷

이미지

<br>

## 💬 리뷰 요구사항

> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 카드 슬러그 데이터를 사용하는 컴포넌트가 마운트될 때마다 항상 최신 데이터를 가져오도록 개선되었습니다.

- **정리**
  - 사용되지 않는 불필요한 코드가 제거되어 코드가 더 깔끔해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->