### PR TITLE
[FEAT]#312 업로드 된 이미지 삭제 시 대체 이미지 표시 및 리페치 추가

### DIFF
--- a/src/components/editor/elements/uploads/element-upload-canvas.tsx
+++ b/src/components/editor/elements/uploads/element-upload-canvas.tsx
@@ -4,6 +4,7 @@ import { Image as KonvaImage, Group, Rect, Text } from 'react-konva';
 import Konva from 'konva';
 import { UploadElement } from '@/types/editor.type';
 import { useImage } from 'react-konva-utils';
+import sweetAlertUtil from '@/utils/common/sweet-alert-util';
 
 interface UploadImageElementProps {
   element: UploadElement;
@@ -35,7 +36,7 @@ const UploadImageElement = forwardRef<Konva.Image, UploadImageElementProps>(
       // 이미지 로드 실패 시 에러 상태로 설정
       if (status === 'failed') {
         setHasError(true);
-        console.warn(`이미지를 불러올 수 없습니다: ${element.previewUrl}`);
+        sweetAlertUtil.error('이미지를 불러올 수 없습니다.');
       } else {
         setHasError(false);
       }

--- a/src/components/editor/elements/uploads/element-upload-canvas.tsx
+++ b/src/components/editor/elements/uploads/element-upload-canvas.tsx
@@ -1,10 +1,9 @@
 'use client';
-import React, { forwardRef, useEffect } from 'react';
-import { Image as KonvaImage } from 'react-konva';
+import React, { forwardRef, useEffect, useState } from 'react';
+import { Image as KonvaImage, Group, Rect, Text } from 'react-konva';
 import Konva from 'konva';
 import { UploadElement } from '@/types/editor.type';
 import { useImage } from 'react-konva-utils';
-import sweetAlertUtil from '@/utils/common/sweet-alert-util';
 
 interface UploadImageElementProps {
   element: UploadElement;
@@ -30,13 +29,58 @@ const UploadImageElement = forwardRef<Konva.Image, UploadImageElementProps>(
     ref
   ) => {
     const [image, status] = useImage(element.previewUrl, 'anonymous');
+    const [hasError, setHasError] = useState(false);
 
     useEffect(() => {
+      // 이미지 로드 실패 시 에러 상태로 설정
       if (status === 'failed') {
-        sweetAlertUtil.error('이미지를 불러올 수 없습니다.');
+        setHasError(true);
+        console.warn(`이미지를 불러올 수 없습니다: ${element.previewUrl}`);
+      } else {
+        setHasError(false);
       }
     }, [status, element.previewUrl]);
 
+    // 이미지 로드 실패 시 대체 UI 반환
+    if (hasError) {
+      return (
+        <Group
+          x={element.x}
+          y={element.y}
+          width={element.width}
+          height={element.height}
+          rotation={element.rotation}
+          draggable={!previewMode}
+          onDragEnd={(e) => onDragEnd(element.id, e.target as Konva.Node)}
+          onDragStart={(e) => onDragStart(element.id, e.target as Konva.Node)}
+          onDragMove={(e) => onDragMove?.(e.target)}
+          onClick={(e) => onSelect(element.id, e.target)}
+          onTap={(e) => onSelect(element.id, e.target)}
+        >
+          {/* 배경 */}
+          <Rect
+            width={element.width}
+            height={element.height}
+            fill='#f8f8f8'
+            stroke='#ddd'
+            strokeWidth={1}
+          />
+
+          {/* 오류 메시지 */}
+          <Text
+            text='이미지를 찾을 수 없습니다'
+            fontSize={Math.min(14, element.width / 10)}
+            fill='#888'
+            width={element.width}
+            height={element.height / 2}
+            align='center'
+            verticalAlign='middle'
+          />
+        </Group>
+      );
+    }
+
+    // 이미지 로딩 중이거나 성공했을 때
     return (
       <KonvaImage
         ref={ref}

--- a/src/hooks/queries/use-card-by-id-single.ts
+++ b/src/hooks/queries/use-card-by-id-single.ts
@@ -17,4 +17,7 @@ export const useCardDataById = (cardId: string) =>
       return data!;
     },
     enabled: !!cardId,
+    staleTime: 0,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: true,
   });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #312

<br>

## 📝 작업 내용

- 삭제된 이미지를 사용한 명함 내 이미지를 대체 이미지 표시
- 강제적인 캐시 무효화 및 최신 데이터 보장 설정

<br>

## 🖼 스크린샷

![스크린샷 2025-04-25 오후 1 26 56](https://github.com/user-attachments/assets/9586b1b8-4806-4b1c-b640-862fc49123b2)

<br>

## 💬 리뷰 요구사항

> 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 이미지 로딩 실패 시 경고창 대신 "이미지를 찾을 수 없습니다"라는 메시지가 표시되는 대체 UI가 제공됩니다.

- **기능 개선**
  - 카드 데이터가 항상 최신 상태로 유지되도록, 화면 진입 및 창 포커스 시 자동으로 데이터를 새로고침합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->