### PR TITLE
Feat/#315 zindex 실제 배열로 반환하도록 변경

### DIFF
--- a/src/components/card/konva-stage-viewer.tsx
+++ b/src/components/card/konva-stage-viewer.tsx
@@ -91,7 +91,6 @@ const CardStageViewer = forwardRef<CardStageViewerRef, CardStageViewerProps>(
                   <TextCanvasElement
                     element={el as TextElement}
                     onDragEnd={() => {}}
-                    onDragStart={() => {}}
                     onDragMove={() => {}}
                     onTransformEnd={() => {}}
                     onDoubleClick={() => {}}
@@ -104,7 +103,6 @@ const CardStageViewer = forwardRef<CardStageViewerRef, CardStageViewerProps>(
                   <UploadImageElement
                     element={el as UploadElement}
                     onDragEnd={() => {}}
-                    onDragStart={() => {}}
                     onDragMove={() => {}}
                     onSelect={() => {}}
                     onTransformEnd={() => {}}
@@ -115,7 +113,6 @@ const CardStageViewer = forwardRef<CardStageViewerRef, CardStageViewerProps>(
                   <UnsplashImageElement
                     element={el as ImageElement}
                     onDragEnd={() => {}}
-                    onDragStart={() => {}}
                     onDragMove={() => {}}
                     onTransformEnd={() => {}}
                     onSelect={() => {}}
@@ -126,7 +123,6 @@ const CardStageViewer = forwardRef<CardStageViewerRef, CardStageViewerProps>(
                   <QrCanvasElement
                     element={el as QrElement}
                     onDragEnd={() => {}}
-                    onDragStart={() => {}}
                     onDragMove={() => {}}
                     onTransformEnd={() => {}}
                     onSelect={() => {}}
@@ -137,7 +133,6 @@ const CardStageViewer = forwardRef<CardStageViewerRef, CardStageViewerProps>(
                   <SocialCanvasElement
                     element={el as SocialElement}
                     onDragEnd={() => {}}
-                    onDragStart={() => {}}
                     onDragMove={() => {}}
                     onTransformEnd={() => {}}
                     onSelect={() => {}}

--- a/src/components/editor/canvas-elements-render.tsx
+++ b/src/components/editor/canvas-elements-render.tsx
@@ -103,10 +103,6 @@ const CanvasElementsRender = ({
       onDragEnd: (id: string, node: Konva.Node) => {
         updateElement(id, { x: node.x(), y: node.y() });
         handleUpdateToolbarNode(node);
-        node.moveToTop();
-      },
-      onDragStart: (id: string, node: Konva.Node) => {
-        node.moveToTop();
       },
 
       onDragMove: (node: Konva.Node) => {

--- a/src/components/editor/editor-ui/element-toolbar/editor-element-toolbar.tsx
+++ b/src/components/editor/editor-ui/element-toolbar/editor-element-toolbar.tsx
@@ -6,8 +6,15 @@ import ToolBarBottom from '@/components/icons/editor/toolbar-move-bottom';
 import ToolbarMoveDown from '@/components/icons/editor/toolbar-move-down';
 import ToolBarTop from '@/components/icons/editor/toolbar-move-top';
 import ToolbarMoveUp from '@/components/icons/editor/toolbar-move-up';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useEditorStore } from '@/store/editor.store';
 import Konva from 'konva';
+import { MoreHorizontal } from 'lucide-react';
 import { Html } from 'react-konva-utils';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -84,22 +91,29 @@ const ElementToolbar = ({ shapeRefs }: ElementToolbarProps) => {
         <button onClick={handleDuplicate}>
           <ToolbarDuplicate className='h-3 w-3 bg-white' />
         </button>
-        <div className='h-[15px] w-[0.5px] bg-gray-10' />
-        <button onClick={() => handleMove('up')}>
-          <ToolbarMoveUp className='h-3 w-3' />
-        </button>
-        <div className='h-[15px] w-[0.5px] bg-gray-10' />
-        <button onClick={() => handleMove('down')}>
-          <ToolbarMoveDown className='h-3 w-3' />
-        </button>
-        <div className='h-[15px] w-[0.5px] bg-gray-10' />
-        <button onClick={() => handleMove('top')}>
-          <ToolBarTop className='h-3 w-3' />
-        </button>
-        <div className='h-[15px] w-[0.5px] bg-gray-10' />
-        <button onClick={() => handleMove('bottom')}>
-          <ToolBarBottom className='h-3 w-3' />
-        </button>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button>
+              <MoreHorizontal className='h-3 w-3' />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='start'>
+            <DropdownMenuItem onSelect={() => handleMove('up')}>
+              위로 이동 <ToolbarMoveUp className='h-3 w-3' />
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => handleMove('down')}>
+              아래로 이동 <ToolbarMoveDown className='h-3 w-3' />
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => handleMove('top')}>
+              맨 위로
+              <ToolBarTop className='h-3 w-3' />
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => handleMove('bottom')}>
+              맨 아래로 <ToolBarBottom className='h-3 w-3' />
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </Html>
   );

--- a/src/components/editor/editor-ui/element-toolbar/editor-element-toolbar.tsx
+++ b/src/components/editor/editor-ui/element-toolbar/editor-element-toolbar.tsx
@@ -91,7 +91,7 @@ const ElementToolbar = ({ shapeRefs }: ElementToolbarProps) => {
         <button onClick={handleDuplicate}>
           <ToolbarDuplicate className='h-3 w-3 bg-white' />
         </button>
-
+        <div className='h-[15px] w-[0.5px] bg-gray-10' />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button>

--- a/src/components/editor/editor-ui/element-toolbar/editor-element-toolbar.tsx
+++ b/src/components/editor/editor-ui/element-toolbar/editor-element-toolbar.tsx
@@ -19,15 +19,18 @@ const ElementToolbar = ({ shapeRefs }: ElementToolbarProps) => {
   const canvasElements = useEditorStore((state) =>
     state.isCanvasFront ? state.canvasElements : state.canvasBackElements
   );
-  const selectedElementId = useEditorStore((s) => s.selectedElementId);
-  const toolbar = useEditorStore((s) => s.toolbar);
-  const removeElement = useEditorStore((s) => s.removeElement);
-  const setSelectedElementId = useEditorStore((s) => s.setSelectedElementId);
+  const selectedElementId = useEditorStore((state) => state.selectedElementId);
+  const toolbar = useEditorStore((state) => state.toolbar);
+  const removeElement = useEditorStore((state) => state.removeElement);
+  const setSelectedElementId = useEditorStore(
+    (state) => state.setSelectedElementId
+  );
   const setSelectedElementType = useEditorStore(
     (s) => s.setSelectedElementType
   );
-  const setToolbar = useEditorStore((s) => s.setToolbar);
-  const addElement = useEditorStore((s) => s.addElement);
+  const setToolbar = useEditorStore((state) => state.setToolbar);
+  const addElement = useEditorStore((state) => state.addElement);
+  const moveElement = useEditorStore((state) => state.moveElement);
 
   if (!selectedElementId || !toolbar) return null;
 
@@ -56,24 +59,7 @@ const ElementToolbar = ({ shapeRefs }: ElementToolbarProps) => {
 
   const handleMove = (direction: 'up' | 'down' | 'top' | 'bottom') => {
     if (!selectedElementId) return;
-    const node = shapeRefs.current[selectedElementId];
-    if (!node) return;
-    switch (direction) {
-      case 'up':
-        node.moveUp();
-        break;
-      case 'down':
-        node.moveDown();
-        break;
-      case 'top':
-        node.moveToTop();
-        break;
-      case 'bottom':
-        node.moveToBottom();
-        break;
-      default:
-        break;
-    }
+    moveElement(selectedElementId, direction);
   };
 
   return (

--- a/src/components/editor/editor-ui/element-toolbar/editor-element-toolbar.tsx
+++ b/src/components/editor/editor-ui/element-toolbar/editor-element-toolbar.tsx
@@ -81,7 +81,7 @@ const ElementToolbar = ({ shapeRefs }: ElementToolbarProps) => {
       }}
     >
       <div
-        className='flex items-center gap-1 rounded-[6px] bg-white px-1 py-1'
+        className='flex items-center gap-1 rounded-[6px] bg-white px-1'
         style={{ boxShadow: '1px 1px 4px rgba(0, 0, 0, 0.1)' }}
       >
         <button onClick={handleDelete} className=''>

--- a/src/components/editor/elements/images/element-image-canvas.tsx
+++ b/src/components/editor/elements/images/element-image-canvas.tsx
@@ -8,7 +8,6 @@ import { ImageElement } from '@/types/editor.type';
 interface UnsplashImageElementProps {
   element: ImageElement;
   onDragEnd: (_id: string, _node: Konva.Node) => void;
-  onDragStart: (_id: string, _node: Konva.Node) => void;
   onDragMove: (_node: Konva.Node) => void;
   onTransformEnd: (_id: string, _e: Konva.KonvaEventObject<Event>) => void;
   onSelect: (_id: string, _node: Konva.Node) => void;
@@ -17,15 +16,7 @@ interface UnsplashImageElementProps {
 
 const UnsplashImageElement = forwardRef<Konva.Image, UnsplashImageElementProps>(
   (
-    {
-      element,
-      onDragEnd,
-      onDragStart,
-      onSelect,
-      onTransformEnd,
-      onDragMove,
-      previewMode,
-    },
+    { element, onDragEnd, onSelect, onTransformEnd, onDragMove, previewMode },
     ref
   ) => {
     const [image] = useImage(element.previewUrl, 'anonymous');
@@ -41,7 +32,6 @@ const UnsplashImageElement = forwardRef<Konva.Image, UnsplashImageElementProps>(
         height={element.height}
         draggable={!previewMode}
         onDragEnd={(e) => onDragEnd(element.id, e.target as Konva.Image)}
-        onDragStart={(e) => onDragStart(element.id, e.target as Konva.Image)}
         onDragMove={(e) => onDragMove?.(e.target)}
         onTransformEnd={(e) => onTransformEnd(element.id, e)}
         onMouseDown={(e) => onSelect(element.id, e.target)}

--- a/src/components/editor/elements/qr-social/element-qr-canvas.tsx
+++ b/src/components/editor/elements/qr-social/element-qr-canvas.tsx
@@ -8,7 +8,6 @@ import { QrElement } from '@/types/editor.type';
 interface QrCanvasElementProps {
   element: QrElement;
   onDragEnd: (_id: string, _node: Konva.Node) => void;
-  onDragStart: (_id: string, _node: Konva.Node) => void;
   onDragMove: (_node: Konva.Node) => void;
   onTransformEnd: (_id: string, _e: Konva.KonvaEventObject<Event>) => void;
   onSelect: (_id: string, _node: Konva.Node) => void;
@@ -17,15 +16,7 @@ interface QrCanvasElementProps {
 
 const QrCanvasElement = forwardRef<Konva.Image, QrCanvasElementProps>(
   (
-    {
-      element,
-      onDragEnd,
-      onDragStart,
-      onTransformEnd,
-      onSelect,
-      onDragMove,
-      previewMode,
-    },
+    { element, onDragEnd, onTransformEnd, onSelect, onDragMove, previewMode },
     ref
   ) => {
     const [image, status] = useImage(element.previewUrl);
@@ -47,7 +38,6 @@ const QrCanvasElement = forwardRef<Konva.Image, QrCanvasElementProps>(
         height={element.height}
         draggable={!previewMode}
         onDragEnd={(e) => onDragEnd(element.id, e.target)}
-        onDragStart={(e) => onDragStart(element.id, e.target as Konva.Image)}
         onDragMove={(e) => onDragMove?.(e.target)}
         onTransformEnd={(e) => onTransformEnd(element.id, e)}
         onMouseDown={(e) => onSelect(element.id, e.target)}

--- a/src/components/editor/elements/qr-social/element-social-canvas.tsx
+++ b/src/components/editor/elements/qr-social/element-social-canvas.tsx
@@ -10,7 +10,6 @@ import { Html as KonvaHtml, useImage } from 'react-konva-utils';
 interface SocialCanvasElementProps {
   element: SocialElement;
   onDragEnd: (_id: string, _node: Konva.Node) => void;
-  onDragStart: (_id: string, _node: Konva.Node) => void;
   onDragMove: (_node: Konva.Node) => void;
   onTransformEnd: (_id: string, _e: Konva.KonvaEventObject<Event>) => void;
   onSelect: (_id: string, _node: Konva.Node) => void;
@@ -29,7 +28,6 @@ const SocialCanvasElement = forwardRef<Konva.Image, SocialCanvasElementProps>(
     {
       element,
       onDragEnd,
-      onDragStart,
       onTransformEnd,
       onSelect,
       onDragMove,
@@ -76,7 +74,6 @@ const SocialCanvasElement = forwardRef<Konva.Image, SocialCanvasElementProps>(
           onDragEnd={(e) => {
             onDragEnd(element.id, e.target);
           }}
-          onDragStart={(e) => onDragStart(element.id, e.target as Konva.Image)}
           onDragMove={(e) => onDragMove?.(e.target)}
           onTransformEnd={(e) => onTransformEnd(element.id, e)}
           onMouseDown={(e) => onSelect(element.id, e.target)}

--- a/src/components/editor/elements/qr-social/qrsocial-sidebar.tsx
+++ b/src/components/editor/elements/qr-social/qrsocial-sidebar.tsx
@@ -180,8 +180,6 @@ const QrSidebar = () => {
   const disabled =
     tab === 'qr' ? !slug || isCheckingSlug : !(social && socialCleanInput);
 
-  console.log(socialFullUrl);
-
   return (
     <div className='flex w-full flex-col items-start gap-[16px] p-[18px]'>
       <div className='flex flex-col items-start gap-2 self-stretch'>
@@ -220,13 +218,14 @@ const QrSidebar = () => {
         <label className='text-label2-medium'>URL</label>
         <div className='flex w-full rounded border px-3 py-2 text-sm'>
           <span className='select-none whitespace-nowrap text-gray-400'>
-            {tab === 'qr' ? 'uuno.vercel.app/' : showUrl}
+            {tab === 'qr' ? 'uuno.vercel.app/' : showUrl || null}
           </span>
           <div className='ml-1 flex-1 overflow-x-auto'>
             {tab === 'qr' ? (
               <>
                 <input
                   type='text'
+                  key='qrInput'
                   {...register('slug')}
                   placeholder={hasSlug ?? 'URL 입력'}
                   className='w-full bg-transparent outline-none'
@@ -236,7 +235,8 @@ const QrSidebar = () => {
             ) : (
               <input
                 type='text'
-                value={inputSocialUrl}
+                key='socialInput'
+                value={inputSocialUrl ?? ''}
                 onChange={(e) => setInputSocialUrl(e.target.value)}
                 placeholder='URL 입력'
                 className='w-full bg-transparent outline-none'

--- a/src/components/editor/elements/templates/templates-sidebar.tsx
+++ b/src/components/editor/elements/templates/templates-sidebar.tsx
@@ -48,26 +48,23 @@ const TemplateSidebar = () => {
   return (
     <div className='mt-[14px] h-full w-full space-y-4 overflow-auto px-[18px]'>
       <p className='text-caption-medium'>템플릿</p>
-      {templates?.data
-        .slice()
-        .reverse()
-        .map((template, idx) => (
-          <div
-            key={template.id}
-            onClick={
-              idx === 0
-                ? () => handleApplyTemplate(template)
-                : sweetComingSoonAlert
-            }
-            className='cursor-pointer space-y-[14px] border'
-          >
-            <img
-              src={template.thumbnail || ''}
-              alt={template.name}
-              className='aspect-[3/2] w-full rounded object-cover px-2'
-            />
-          </div>
-        ))}
+      {templates?.data.slice().map((template, idx) => (
+        <div
+          key={template.id}
+          onClick={
+            idx === 0
+              ? () => handleApplyTemplate(template)
+              : sweetComingSoonAlert
+          }
+          className='cursor-pointer space-y-[14px] border'
+        >
+          <img
+            src={template.thumbnail || ''}
+            alt={template.name}
+            className='aspect-[3/2] w-full rounded object-cover px-2'
+          />
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/components/editor/elements/text/element-text-canvas.tsx
+++ b/src/components/editor/elements/text/element-text-canvas.tsx
@@ -11,7 +11,6 @@ export interface TextCanvasElementProps {
   onTransformEnd: (_id: string, _e: Konva.KonvaEventObject<Event>) => void;
   onDoubleClick: (_id: string) => void;
   onSelect: (_id: string, _node: Konva.Node) => void;
-  onDragStart: (_id: string, _node: Konva.Node) => void;
   editing: boolean;
   previewMode?: boolean;
 }
@@ -22,7 +21,7 @@ const TextCanvasElement = forwardRef<Konva.Text, TextCanvasElementProps>(
       element,
       onDragEnd,
       onDragMove,
-      onDragStart,
+
       onTransformEnd,
       onDoubleClick,
       onSelect,
@@ -47,7 +46,6 @@ const TextCanvasElement = forwardRef<Konva.Text, TextCanvasElementProps>(
         onDragEnd={(e) => onDragEnd(element.id, e.target as Konva.Text)}
         onDragMove={(e) => onDragMove?.(e.target)}
         onTransformEnd={(e) => onTransformEnd(element.id, e)}
-        onDragStart={(e) => onDragStart(element.id, e.target as Konva.Text)}
         onDblClick={() => onDoubleClick(element.id)}
         onDblTap={() => onDoubleClick(element.id)}
         onMouseDown={(e) => onSelect(element.id, e.target)}

--- a/src/components/editor/elements/uploads/element-upload-canvas.tsx
+++ b/src/components/editor/elements/uploads/element-upload-canvas.tsx
@@ -12,21 +12,12 @@ interface UploadImageElementProps {
   onDragMove?: (_node: Konva.Node) => void;
   onTransformEnd: (_id: string, _e: Konva.KonvaEventObject<Event>) => void;
   onSelect: (_id: string, _node: Konva.Node) => void;
-  onDragStart: (_id: string, _node: Konva.Node) => void;
   previewMode?: boolean;
 }
 
 const UploadImageElement = forwardRef<Konva.Image, UploadImageElementProps>(
   (
-    {
-      element,
-      onDragEnd,
-      onDragStart,
-      onSelect,
-      onTransformEnd,
-      onDragMove,
-      previewMode,
-    },
+    { element, onDragEnd, onSelect, onTransformEnd, onDragMove, previewMode },
     ref
   ) => {
     const [image, status] = useImage(element.previewUrl, 'anonymous');
@@ -53,7 +44,7 @@ const UploadImageElement = forwardRef<Konva.Image, UploadImageElementProps>(
           rotation={element.rotation}
           draggable={!previewMode}
           onDragEnd={(e) => onDragEnd(element.id, e.target as Konva.Node)}
-          onDragStart={(e) => onDragStart(element.id, e.target as Konva.Node)}
+          // onDragStart={(e) => onDragStart(element.id, e.target as Konva.Node)}
           onDragMove={(e) => onDragMove?.(e.target)}
           onClick={(e) => onSelect(element.id, e.target)}
           onTap={(e) => onSelect(element.id, e.target)}
@@ -93,7 +84,6 @@ const UploadImageElement = forwardRef<Konva.Image, UploadImageElementProps>(
         height={element.height}
         draggable={!previewMode}
         onDragEnd={(e) => onDragEnd(element.id, e.target as Konva.Image)}
-        onDragStart={(e) => onDragStart(element.id, e.target as Konva.Image)}
         onDragMove={(e) => onDragMove?.(e.target)}
         onTransformEnd={(e) => onTransformEnd(element.id, e)}
         onMouseDown={(e) => onSelect(element.id, e.target)}

--- a/src/constants/editor.constant.ts
+++ b/src/constants/editor.constant.ts
@@ -100,7 +100,7 @@ export const MAX_ZOOM = 3;
 export const MIN_ZOOM = 0.3;
 export const ZOOM_RATION = 0.1;
 
-export const TOOLBAR_WIDTH = 122;
+export const TOOLBAR_WIDTH = 56;
 
 export const BASE_STAGE_WIDTH = 468;
 export const BASE_STAGE_HEIGHT = 244;

--- a/src/store/editor.store.ts
+++ b/src/store/editor.store.ts
@@ -70,6 +70,11 @@ export interface EditorState {
 
   //템플릿
   setTemplate: (element: Templates | null) => void;
+
+  moveElement: (
+    id: string,
+    direction: 'up' | 'down' | 'top' | 'bottom'
+  ) => void;
 }
 
 export const useEditorStore = create<EditorState>()(
@@ -270,6 +275,31 @@ export const useEditorStore = create<EditorState>()(
       setTemplate: (element) => {
         set({ template: element });
       },
+
+      moveElement: (id: string, direction: 'up' | 'down' | 'top' | 'bottom') =>
+        set((state) => {
+          const key = state.isCanvasFront
+            ? 'canvasElements'
+            : 'canvasBackElements';
+          const list = [...state[key]];
+          const idx = list.findIndex((el) => el.id === id);
+          if (idx < 0) return {};
+
+          let targetIdx =
+            direction === 'up'
+              ? Math.min(list.length - 1, idx + 1)
+              : direction === 'down'
+                ? Math.max(0, idx - 1)
+                : direction === 'top'
+                  ? list.length - 1
+                  : 0;
+          if (targetIdx === idx) return {};
+
+          const [item] = list.splice(idx, 1);
+          list.splice(targetIdx, 0, item);
+
+          return { [key]: list };
+        }),
     }),
     {
       name: 'editor-storage',


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #315 

<br>

## 📝 

이 변경사항은 에디터의 zIndex(레이어 순서) 조작 방식을 기존의 Konva 노드 메서드(moveToTop 등)에서 실제 요소 배열을 직접 수정하는 방식으로 전환합니다. 드래그 시작 시 요소를 최상단으로 이동하는 로직과 관련 핸들러가 삭제되고, 툴바에서의 레이어 이동은 중앙 집중화된 store 메서드(moveElement)를 통해 처리됩니다. 여러 요소 타입의 onDragStart 프로퍼티와 관련 타입 정의도 제거되었습니다. 툴바 UI는 드롭다운 메뉴로 정리되었으며, 기타 입력 필드의 렌더링 및 상수 값 일부가 조정되었습니다.

- zindex를 실제 배열로 반환해서 편집하기 및 저장 했을 때 문제를 해결하도록 했습니다
- 디자이너님 요청사항에 맞게 드롭박스메뉴를 추가해서 조절 가능하도록 변경 했습니다

<br>

<img width="917" alt="스크린샷 2025-04-25 오후 10 45 46" src="https://github.com/user-attachments/assets/10421421-784a-4938-b7a4-080ae8c2e2c4" />


이미지

<br>

## 💬 리뷰 요구사항

> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 요소의 순서를 변경할 수 있는 드롭다운 메뉴가 툴바에 추가되었습니다.

- **버그 수정**
	- 드래그 시작 시 요소의 위치가 예기치 않게 변경되는 현상이 수정되었습니다.

- **UI 개선**
	- 요소 툴바의 너비가 축소되어 화면이 더 넓게 활용됩니다.
	- 요소 이동 버튼이 드롭다운 메뉴로 통합되어 인터페이스가 간결해졌습니다.
	- 템플릿 사이드바에서 템플릿 목록이 원래 순서대로 표시됩니다.

- **기타**
	- 입력 필드의 값 처리와 렌더링 안정성이 향상되었습니다.
	- 드래그 시작 이벤트 핸들러가 여러 요소에서 제거되어 코드가 간결해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->