### PR TITLE
[FEAT]#347 요소 삭제 키보드 이벤트

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -8,6 +8,7 @@ import EditorTopbar from '@/components/editor/editor-ui/topbar/editor-topbar';
 import CanvasSelectModal from '@/components/editor/modal/editor-vt-hr-select-modal';
 import { useCardDataById } from '@/hooks/queries/use-card-by-id-single';
 import { getTemplateData } from '@/hooks/queries/use-template-single';
+import { useRedoUndoPress } from '@/hooks/use-redo-undo-press';
 import { useEditorStore } from '@/store/editor.store';
 import { CardContent } from '@/types/cards.type';
 import { TemplateContent } from '@/types/templates.type';
@@ -104,31 +105,7 @@ const EditPage = () => {
   }, [cardData, templateData, sessionContent, setSlug]);
 
   // undo redo 커맨드 키
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
-      const ctrlOrCmd = isMac ? e.metaKey : e.ctrlKey;
-
-      if (ctrlOrCmd && e.key.toLowerCase() === 'z') {
-        e.preventDefault();
-        if (e.shiftKey) {
-          // Ctrl+Shift+Z or Cmd+Shift+Z
-          redo();
-        } else {
-          // Ctrl+Z or Cmd+Z
-          undo();
-        }
-      }
-      // Ctrl + y
-      if (ctrlOrCmd && e.key.toLocaleLowerCase() === 'y') {
-        e.preventDefault();
-        redo();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo]);
+  useRedoUndoPress();
 
   const isHorizontal = cardData
     ? cardData.isHorizontal

--- a/src/components/editor/editor-ui/element-toolbar/editor-element-toolbar.tsx
+++ b/src/components/editor/editor-ui/element-toolbar/editor-element-toolbar.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useDeleteKeyPress } from '@/hooks/use-delete-key-press';
 import { useEditorStore } from '@/store/editor.store';
 import Konva from 'konva';
 import { MoreHorizontal } from 'lucide-react';
@@ -39,14 +40,15 @@ const ElementToolbar = ({ shapeRefs }: ElementToolbarProps) => {
   const addElement = useEditorStore((state) => state.addElement);
   const moveElement = useEditorStore((state) => state.moveElement);
 
-  if (!selectedElementId || !toolbar) return null;
-
   const handleDelete = () => {
+    if (!selectedElementId) return;
     removeElement(selectedElementId);
     setSelectedElementId(null);
     setSelectedElementType(null);
     setToolbar(null);
   };
+
+  useDeleteKeyPress({ handleDelete });
 
   const handleDuplicate = () => {
     const original = canvasElements.find((el) => el.id === selectedElementId);
@@ -69,6 +71,7 @@ const ElementToolbar = ({ shapeRefs }: ElementToolbarProps) => {
     moveElement(selectedElementId, direction);
   };
 
+  if (!selectedElementId || !toolbar) return null;
   return (
     <Html
       divProps={{

--- a/src/hooks/use-delete-key-press.ts
+++ b/src/hooks/use-delete-key-press.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+interface useDeleteKeyPressProps {
+  handleDelete: () => void;
+}
+
+export const useDeleteKeyPress = ({ handleDelete }: useDeleteKeyPressProps) => {
+  useEffect(() => {
+    const isMac = navigator.userAgent.match(/Mac/i);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isMac) {
+        if (e.key === 'Backspace') {
+          handleDelete();
+        }
+      } else {
+        if (e.key === 'Delete') {
+          handleDelete();
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleDelete]);
+};

--- a/src/hooks/use-delete-key-press.ts
+++ b/src/hooks/use-delete-key-press.ts
@@ -9,8 +9,10 @@ export const useDeleteKeyPress = ({ handleDelete }: useDeleteKeyPressProps) => {
     const isMac = navigator.userAgent.match(/Mac/i);
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      const cmd = e.metaKey;
+
       if (isMac) {
-        if (e.key === 'Backspace') {
+        if (cmd && e.key === 'Backspace') {
           handleDelete();
         }
       } else {

--- a/src/hooks/use-redo-undo-press.ts
+++ b/src/hooks/use-redo-undo-press.ts
@@ -1,0 +1,33 @@
+import { useEditorStore } from '@/store/editor.store';
+import { useEffect } from 'react';
+
+export const useRedoUndoPress = () => {
+  const redo = useEditorStore((state) => state.redo);
+  const undo = useEditorStore((state) => state.undo);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isMac = navigator.userAgent.match(/Mac|iPod|iPhone|iPad/i);
+      const ctrlOrCmd = isMac ? e.metaKey : e.ctrlKey;
+
+      if (ctrlOrCmd && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        if (e.shiftKey) {
+          // Ctrl+Shift+Z or Cmd+Shift+Z
+          redo();
+        } else {
+          // Ctrl+Z or Cmd+Z
+          undo();
+        }
+      }
+      // Ctrl + y
+      if (ctrlOrCmd && e.key.toLocaleLowerCase() === 'y') {
+        e.preventDefault();
+        redo();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [undo, redo]);
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #347 

<br>

## 📝 작업 내용

- 요소 삭제 키보드 이벤트 추가 (맥 Backspace, 위도우 delete)
- 기존 undo redo 키보드 이벤트 커스텀 훅으로 분리

<br>

## 💬 리뷰 요구사항

> 제가 맥이 없어서 맥은 테스트 해주시면 감사하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 삭제 키(Windows: Delete, Mac: Cmd+Backspace)로 선택된 요소를 삭제할 수 있는 기능이 추가되었습니다.
    - 키보드 단축키(Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z, Ctrl/Cmd+Y)를 통한 실행 취소 및 다시 실행 기능이 개선되었습니다.

- **리팩터**
    - 실행 취소 및 다시 실행 단축키 처리가 별도의 커스텀 훅으로 분리되어 코드가 간결해졌습니다.
    - 삭제 키 이벤트 처리 로직이 커스텀 훅으로 추출되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->