### PR TITLE
[FEAT]#369 헤더 반응형 

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import ScrollToTopButton from '@/components/main/ScrollToTopButton';
 
 export default function Homepage() {
   return (
-    <div className='flex flex-col'>
+    <div className='flex w-full flex-col'>
       <MainIntorSection />
       <MainFeatureSection />
       <MainTipSection />

--- a/src/components/common/common-button.tsx
+++ b/src/components/common/common-button.tsx
@@ -29,6 +29,7 @@ const buttonVariants = cva(
         medium: 'py-1.5',
         large: 'py-3',
         xlarge: 'py-[14px]',
+        mobile: 'px-3 py-[6px]',
       },
       // border-radius 옵션: "6px"와 "full" 중 선택
       borderRadius: {
@@ -45,6 +46,11 @@ const buttonVariants = cva(
       },
       {
         variant: 'secondary',
+        size: 'xlarge',
+        className: 'rounded-full',
+      },
+      {
+        variant: 'tertiary',
         size: 'xlarge',
         className: 'rounded-full',
       },

--- a/src/components/common/common-button.tsx
+++ b/src/components/common/common-button.tsx
@@ -29,7 +29,7 @@ const buttonVariants = cva(
         medium: 'py-1.5',
         large: 'py-3',
         xlarge: 'py-[14px]',
-        mobile: 'px-3 py-[6px]',
+        mobile: 'py-[6px]',
       },
       // border-radius 옵션: "6px"와 "full" 중 선택
       borderRadius: {

--- a/src/components/layouts/nav-bar.tsx
+++ b/src/components/layouts/nav-bar.tsx
@@ -18,6 +18,7 @@ import { Icon } from '@iconify/react';
 import { useRouter } from 'next/navigation';
 import { modalStore } from '@/store/modal.store';
 import Image from 'next/image';
+import { useSheetStore } from '@/store/sheet.store';
 
 interface Props {
   // Supabase Auth의 User 타입
@@ -28,6 +29,8 @@ const NavBar = ({ user }: Props) => {
   const setIsOpen = modalStore((state) => state.setIsOpen);
   const setModalState = modalStore((state) => state.setModalState);
   const router = useRouter();
+  const openSheet = useSheetStore((state) => state.open);
+  const closeSheet = useSheetStore((state) => state.close);
   const userNickName =
     user?.user_metadata.nick_name || user?.user_metadata.full_name;
 
@@ -37,21 +40,101 @@ const NavBar = ({ user }: Props) => {
       e.preventDefault();
       setModalState('login');
       setIsOpen(true);
+      closeSheet();
     } else {
       router.push(ROUTES.DASHBOARD.BASE);
+      closeSheet();
     }
   };
 
   const menuLinkStyle =
     'inline-block px-3 py-[6px] text-label1-medium transition-colors hover:text-primary-40';
 
+  const mobileMenu = (
+    <div className='flex h-full w-full flex-col items-start px-[22px] pt-[30px]'>
+      {/* 1. 유저 정보 */}
+      {user ? (
+        <div className='flex flex-col items-start'>
+          <div className='text-label1-semi text-black'>{userNickName}</div>
+          <div className='mt-[6px] text-label1-medium text-gray-70'>
+            {user?.email}
+          </div>
+        </div>
+      ) : (
+        <Image
+          src='/main-logo-black.png'
+          alt='로고 이미지'
+          width={66}
+          height={26}
+        />
+      )}
+
+      {/*  첫 번째 구분선  */}
+
+      {/* 3. 메뉴 리스트 (아이템 간 8px) */}
+      <nav className='flex w-full flex-col space-y-[8px]'>
+        <div className='mt-[20px] h-px w-full bg-gray-5' />
+        <Link
+          href={ROUTES.TEMPLATES.BASE}
+          onClick={closeSheet}
+          className='flex items-center gap-2 py-3 text-label2-medium text-black'
+        >
+          <Icon icon='tdesign:layout' width='20' height='20' />
+          템플릿
+        </Link>
+        {/* <Link
+          href={ROUTES.EDITOR}
+          onClick={closeSheet}
+          className='flex items-center gap-2 py-3 text-label2-medium text-black'
+        >
+          <Icon icon='tdesign:edit-1' width='20' height='20' />
+          만들기
+        </Link> */}
+        <Link
+          href={ROUTES.DASHBOARD.MYCARDS}
+          onClick={(e) => {
+            handleMyCardsClick(e);
+          }}
+          className='flex items-center gap-2 py-3 text-label2-medium text-black'
+        >
+          <Icon icon='tdesign:assignment-user' width='20' height='20' />내 명함
+        </Link>
+        <Link
+          href={ROUTES.DASHBOARD.ACCOUNT}
+          onClick={closeSheet}
+          className='flex items-center gap-2 py-3 text-label2-medium text-black'
+        >
+          <Icon icon='tdesign:setting-1' width='20' height='20' />
+          계정 설정
+        </Link>
+
+        {user && (
+          <button
+            className='flex items-center gap-2 py-3 text-label2-medium text-black'
+            onClick={closeSheet}
+          >
+            <Icon icon='tdesign:poweroff' width='20' height='2-' />
+            <HeaderAuthButton type='logout' />
+          </button>
+        )}
+      </nav>
+    </div>
+  );
+
   return (
     <nav className='mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-4 sm:px-0'>
+      {/*모바일 햄버거 */}
       <Icon
         icon='tdesign:view-list'
         width='24'
         height='24'
-        className='sm:hidden'
+        className='cursor-pointer sm:hidden'
+        onClick={() =>
+          openSheet({
+            content: mobileMenu,
+            side: 'left',
+          })
+        }
       />
 
       {/* 로고  */}
@@ -84,13 +167,15 @@ const NavBar = ({ user }: Props) => {
       </div>
 
       {/* 모바일 로그인 */}
-      {!user && (
+      {!user ? (
         <button
           className='flex items-center justify-center rounded-[6px] bg-primary-40 px-3 py-[6px] text-label2-medium sm:hidden'
           onClick={() => setIsOpen(true)}
         >
           로그인
         </button>
+      ) : (
+        <div />
       )}
 
       {/* 우측: 로그인, 내 명함 만들기 버튼 */}

--- a/src/components/layouts/nav-bar.tsx
+++ b/src/components/layouts/nav-bar.tsx
@@ -35,6 +35,9 @@ const NavBar = ({ user }: Props) => {
   const userNickName =
     user?.user_metadata.nick_name || user?.user_metadata.full_name;
 
+  const menuLinkStyle =
+    'inline-block px-3 py-[6px] text-label1-medium transition-colors hover:text-primary-40';
+
   // 내 명함 메뉴 클릭 핸들러
   const handleMyCardsClick = (e: React.MouseEvent) => {
     if (!user) {
@@ -59,9 +62,6 @@ const NavBar = ({ user }: Props) => {
     return () => window.removeEventListener('resize', handleResize);
   }, [isSheetOpen, closeSheet]);
 
-  const menuLinkStyle =
-    'inline-block px-3 py-[6px] text-label1-medium transition-colors hover:text-primary-40';
-
   const mobileMenu = (
     <div className='flex h-full w-full flex-col items-start px-[22px] pt-[30px]'>
       {/* 1. 유저 정보 */}
@@ -81,10 +81,9 @@ const NavBar = ({ user }: Props) => {
         />
       )}
 
-      {/*  첫 번째 구분선  */}
-
-      {/* 3. 메뉴 리스트 (아이템 간 8px) */}
+      {/* 메뉴 리스트  */}
       <nav className='flex w-full flex-col space-y-[8px]'>
+        {/*  첫 번째 구분선  */}
         <div className='mt-[20px] h-px w-full bg-gray-5' />
         <Link
           href={ROUTES.TEMPLATES.BASE}
@@ -190,6 +189,7 @@ const NavBar = ({ user }: Props) => {
           로그인
         </button>
       ) : (
+        // 139번째 줄 justify-between으로 뒀기 때문에 자리를 잡아야 합니다
         <div />
       )}
 

--- a/src/components/layouts/nav-bar.tsx
+++ b/src/components/layouts/nav-bar.tsx
@@ -3,7 +3,7 @@
 import { UserMetadata } from '@supabase/supabase-js';
 import { ROUTES } from '@/constants/path.constant';
 import Link from 'next/link';
-import React from 'react';
+import React, { useEffect } from 'react';
 import HeaderAuthButton from '@/components/layouts/header-auth-button';
 import {
   DropdownMenu,
@@ -30,6 +30,7 @@ const NavBar = ({ user }: Props) => {
   const setModalState = modalStore((state) => state.setModalState);
   const router = useRouter();
   const openSheet = useSheetStore((state) => state.open);
+  const isSheetOpen = useSheetStore((s) => s.isOpen);
   const closeSheet = useSheetStore((state) => state.close);
   const userNickName =
     user?.user_metadata.nick_name || user?.user_metadata.full_name;
@@ -46,6 +47,17 @@ const NavBar = ({ user }: Props) => {
       closeSheet();
     }
   };
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 525 && isSheetOpen) {
+        closeSheet();
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [isSheetOpen, closeSheet]);
 
   const menuLinkStyle =
     'inline-block px-3 py-[6px] text-label1-medium transition-colors hover:text-primary-40';
@@ -99,30 +111,33 @@ const NavBar = ({ user }: Props) => {
         >
           <Icon icon='tdesign:assignment-user' width='20' height='20' />내 명함
         </Link>
-        <Link
-          href={ROUTES.DASHBOARD.ACCOUNT}
-          onClick={closeSheet}
-          className='flex items-center gap-2 py-3 text-label2-medium text-black'
-        >
-          <Icon icon='tdesign:setting-1' width='20' height='20' />
-          계정 설정
-        </Link>
 
         {user && (
-          <button
-            className='flex items-center gap-2 py-3 text-label2-medium text-black'
-            onClick={closeSheet}
-          >
-            <Icon icon='tdesign:poweroff' width='20' height='2-' />
-            <HeaderAuthButton type='logout' />
-          </button>
+          <>
+            <Link
+              href={ROUTES.DASHBOARD.ACCOUNT}
+              onClick={closeSheet}
+              className='flex items-center gap-2 py-3 text-label2-medium text-black'
+            >
+              <Icon icon='tdesign:setting-1' width='20' height='20' />
+              계정 설정
+            </Link>
+
+            <button
+              className='flex items-center gap-2 py-3 text-label2-medium text-black'
+              onClick={closeSheet}
+            >
+              <Icon icon='tdesign:poweroff' width='20' height='2-' />
+              <HeaderAuthButton type='logout' />
+            </button>
+          </>
         )}
       </nav>
     </div>
   );
 
   return (
-    <nav className='mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-4 min-[525px]:px-0'>
+    <nav className='mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-4 min-[1024px]:px-0'>
       {/*모바일 햄버거 */}
       <Icon
         icon='tdesign:view-list'

--- a/src/components/layouts/nav-bar.tsx
+++ b/src/components/layouts/nav-bar.tsx
@@ -122,13 +122,13 @@ const NavBar = ({ user }: Props) => {
   );
 
   return (
-    <nav className='mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-4 sm:px-0'>
+    <nav className='mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-4 min-[525px]:px-0'>
       {/*모바일 햄버거 */}
       <Icon
         icon='tdesign:view-list'
         width='24'
         height='24'
-        className='cursor-pointer sm:hidden'
+        className='cursor-pointer min-[525px]:hidden'
         onClick={() =>
           openSheet({
             content: mobileMenu,
@@ -139,7 +139,7 @@ const NavBar = ({ user }: Props) => {
 
       {/* 로고  */}
       <div className='flex items-center'>
-        <Link href={ROUTES.HOME} className='sm:mr-16'>
+        <Link href={ROUTES.HOME} className='min-[525px]:mr-16'>
           <Image
             src={'/icons/logo_white.svg'}
             width={60}
@@ -148,7 +148,7 @@ const NavBar = ({ user }: Props) => {
           />
         </Link>
         {/* 450px이상 pc버전 메뉴  */}
-        <div className='hidden w-full flex-1 items-center justify-center space-x-8 sm:flex'>
+        <div className='hidden w-full flex-1 items-center justify-center space-x-8 min-[525px]:flex'>
           <Link href={ROUTES.TEMPLATES.BASE} className={menuLinkStyle}>
             템플릿
           </Link>
@@ -169,7 +169,7 @@ const NavBar = ({ user }: Props) => {
       {/* 모바일 로그인 */}
       {!user ? (
         <button
-          className='flex items-center justify-center rounded-[6px] bg-primary-40 px-3 py-[6px] text-label2-medium sm:hidden'
+          className='flex items-center justify-center rounded-[6px] bg-primary-40 px-3 py-[6px] text-label2-medium min-[525px]:hidden'
           onClick={() => setIsOpen(true)}
         >
           로그인
@@ -179,7 +179,7 @@ const NavBar = ({ user }: Props) => {
       )}
 
       {/* 우측: 로그인, 내 명함 만들기 버튼 */}
-      <div className='hidden items-center gap-3 sm:flex'>
+      <div className='hidden items-center gap-3 min-[525px]:flex'>
         {!user ? (
           // 비로그인 : 로그인 + 내 명함 만들기
           <>
@@ -189,7 +189,7 @@ const NavBar = ({ user }: Props) => {
             </CommonButton>
           </>
         ) : (
-          <div className='hidden items-center gap-3 sm:flex'>
+          <div className='hidden items-center gap-3 min-[525px]:flex'>
             <DropdownMenu>
               {/* 닉네임 + 아래쪽 화살표 */}
               <DropdownMenuTrigger asChild>

--- a/src/components/layouts/nav-bar.tsx
+++ b/src/components/layouts/nav-bar.tsx
@@ -142,6 +142,7 @@ const NavBar = ({ user }: Props) => {
         icon='tdesign:view-list'
         width='24'
         height='24'
+        aria-label='메뉴 열기'
         className='cursor-pointer min-[525px]:hidden'
         onClick={() =>
           openSheet({

--- a/src/components/layouts/nav-bar.tsx
+++ b/src/components/layouts/nav-bar.tsx
@@ -64,7 +64,7 @@ const NavBar = ({ user }: Props) => {
 
   const mobileMenu = (
     <div className='flex h-full w-full flex-col items-start px-[22px] pt-[30px]'>
-      {/* 1. 유저 정보 */}
+      {/* 유저 정보 */}
       {user ? (
         <div className='flex flex-col items-start'>
           <div className='text-label1-semi text-black'>{userNickName}</div>
@@ -126,7 +126,7 @@ const NavBar = ({ user }: Props) => {
               className='flex items-center gap-2 py-3 text-label2-medium text-black'
               onClick={closeSheet}
             >
-              <Icon icon='tdesign:poweroff' width='20' height='2-' />
+              <Icon icon='tdesign:poweroff' width='20' height='20' />
               <HeaderAuthButton type='logout' />
             </button>
           </>
@@ -137,7 +137,7 @@ const NavBar = ({ user }: Props) => {
 
   return (
     <nav className='mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-4 min-[1024px]:px-0'>
-      {/*모바일 햄버거 */}
+      {/* 모바일 햄버거 */}
       <Icon
         icon='tdesign:view-list'
         width='24'

--- a/src/components/layouts/nav-bar.tsx
+++ b/src/components/layouts/nav-bar.tsx
@@ -31,9 +31,6 @@ const NavBar = ({ user }: Props) => {
   const userNickName =
     user?.user_metadata.nick_name || user?.user_metadata.full_name;
 
-  const menuLinkStyle =
-    'inline-block px-5 py-2 text-label1-medium transition-colors hover:text-primary-40';
-
   // 내 명함 메뉴 클릭 핸들러
   const handleMyCardsClick = (e: React.MouseEvent) => {
     if (!user) {
@@ -45,119 +42,150 @@ const NavBar = ({ user }: Props) => {
     }
   };
 
+  const menuLinkStyle =
+    'inline-block px-3 py-[6px] text-label1-medium transition-colors hover:text-primary-40';
+
   return (
-    <nav className='mx-auto flex h-16 w-full max-w-5xl items-center justify-between'>
-      {/* 좌측: 로고 & 메뉴 */}
-      <div className='flex items-center gap-4'>
-        <Link href={ROUTES.HOME}>
+    <nav className='mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-4 sm:px-0'>
+      <Icon
+        icon='tdesign:view-list'
+        width='24'
+        height='24'
+        className='sm:hidden'
+      />
+
+      {/* 로고  */}
+      <div className='flex items-center'>
+        <Link href={ROUTES.HOME} className='sm:mr-16'>
           <Image
             src={'/icons/logo_white.svg'}
-            width={64}
-            height={28}
+            width={60}
+            height={23}
             alt='로고 이미지'
           />
         </Link>
-        <Link href={ROUTES.TEMPLATES.BASE} className={menuLinkStyle}>
-          템플릿
-        </Link>
-        <Link href={ROUTES.EDITOR} className={menuLinkStyle}>
-          만들기
-        </Link>
+        {/* 450px이상 pc버전 메뉴  */}
+        <div className='hidden w-full flex-1 items-center justify-center space-x-8 sm:flex'>
+          <Link href={ROUTES.TEMPLATES.BASE} className={menuLinkStyle}>
+            템플릿
+          </Link>
+          <Link href={ROUTES.EDITOR} className={menuLinkStyle}>
+            만들기
+          </Link>
 
-        <button
-          onClick={handleMyCardsClick}
-          role='link'
-          className={menuLinkStyle}
-        >
-          내 명함
-        </button>
+          <button
+            onClick={handleMyCardsClick}
+            role='link'
+            className={menuLinkStyle}
+          >
+            내 명함
+          </button>
+        </div>
       </div>
 
-      {/* 우측: 로그인, 내 명함 만들기 버튼 */}
-
-      {!user ? (
-        // 비로그인 : 로그인 + 내 명함 만들기
-        <div className='flex gap-3'>
-          <HeaderAuthButton type='login' />
-          <CommonButton asChild className='text-label2-medium'>
-            <Link href={ROUTES.EDITOR}>내 명함 만들기</Link>
-          </CommonButton>
-        </div>
-      ) : (
-        // 로그인상태 : 닉네임 + 드롭다운 메뉴
-        <DropdownMenu>
-          {/* 닉네임 + 아래쪽 화살표 */}
-          <DropdownMenuTrigger asChild>
-            <button className='flex items-center px-[14px] py-[6px] text-label1-bold focus:outline-none'>
-              {userNickName}{' '}
-              <Icon icon='tdesign:caret-down-small' width='16' height='16' />
-            </button>
-          </DropdownMenuTrigger>
-
-          {/* 드롭다운 박스 */}
-          <DropdownMenuContent
-            side='bottom'
-            align='end'
-            className='w-[208px] -translate-x-2'
-          >
-            {/* 사용자 정보 */}
-            <DropdownMenuLabel>
-              <div className='text-label2-bold text-black'>{userNickName}</div>
-              <div className='mt-1 text-extra-medium text-gray-70'>
-                {user.email}
-              </div>
-            </DropdownMenuLabel>
-
-            {/* 구분선 */}
-            <DropdownMenuSeparator />
-
-            {/* 메뉴 항목 */}
-            <DropdownMenuItem asChild>
-              <Link
-                href={ROUTES.DASHBOARD.MYCARDS}
-                className='text-extra-medium text-black'
-              >
-                {' '}
-                <Icon
-                  icon='tdesign:assignment-user'
-                  width='18'
-                  height='18'
-                  className='text-black'
-                />
-                내 명함
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link
-                href={ROUTES.DASHBOARD.ACCOUNT}
-                className='text-extra-medium text-black'
-              >
-                <Icon
-                  icon='tdesign:setting-1'
-                  width='18'
-                  height='18'
-                  className='text-black'
-                />
-                계정 설정
-              </Link>
-            </DropdownMenuItem>
-
-            {/* 구분선 */}
-            <DropdownMenuSeparator />
-
-            {/* 로그아웃 */}
-            <DropdownMenuItem className='flex items-center'>
-              <Icon
-                icon='tdesign:poweroff'
-                width='18'
-                height='18'
-                className='text-black'
-              />
-              <HeaderAuthButton type='logout' />
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+      {/* 모바일 로그인 */}
+      {!user && (
+        <button
+          className='flex items-center justify-center rounded-[6px] bg-primary-40 px-3 py-[6px] text-label2-medium sm:hidden'
+          onClick={() => setIsOpen(true)}
+        >
+          로그인
+        </button>
       )}
+
+      {/* 우측: 로그인, 내 명함 만들기 버튼 */}
+      <div className='hidden items-center gap-3 sm:flex'>
+        {!user ? (
+          // 비로그인 : 로그인 + 내 명함 만들기
+          <>
+            <HeaderAuthButton type='login' />
+            <CommonButton asChild className='text-label2-medium'>
+              <Link href={ROUTES.EDITOR}>내 명함 만들기</Link>
+            </CommonButton>
+          </>
+        ) : (
+          <div className='hidden items-center gap-3 sm:flex'>
+            <DropdownMenu>
+              {/* 닉네임 + 아래쪽 화살표 */}
+              <DropdownMenuTrigger asChild>
+                <button className='flex items-center px-[14px] py-[6px] text-label1-bold focus:outline-none'>
+                  {userNickName}{' '}
+                  <Icon
+                    icon='tdesign:caret-down-small'
+                    width='16'
+                    height='16'
+                  />
+                </button>
+              </DropdownMenuTrigger>
+
+              {/* 드롭다운 박스 */}
+              <DropdownMenuContent
+                side='bottom'
+                align='end'
+                className='w-[208px] -translate-x-2'
+              >
+                {/* 사용자 정보 */}
+                <DropdownMenuLabel>
+                  <div className='text-label2-bold text-black'>
+                    {userNickName}
+                  </div>
+                  <div className='mt-1 text-extra-medium text-gray-70'>
+                    {user.email}
+                  </div>
+                </DropdownMenuLabel>
+
+                {/* 구분선 */}
+                <DropdownMenuSeparator />
+
+                {/* 메뉴 항목 */}
+                <DropdownMenuItem asChild>
+                  <Link
+                    href={ROUTES.DASHBOARD.MYCARDS}
+                    className='text-extra-medium text-black'
+                  >
+                    {' '}
+                    <Icon
+                      icon='tdesign:assignment-user'
+                      width='18'
+                      height='18'
+                      className='text-black'
+                    />
+                    내 명함
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link
+                    href={ROUTES.DASHBOARD.ACCOUNT}
+                    className='text-extra-medium text-black'
+                  >
+                    <Icon
+                      icon='tdesign:setting-1'
+                      width='18'
+                      height='18'
+                      className='text-black'
+                    />
+                    계정 설정
+                  </Link>
+                </DropdownMenuItem>
+
+                {/* 구분선 */}
+                <DropdownMenuSeparator />
+
+                {/* 로그아웃 */}
+                <DropdownMenuItem className='flex items-center'>
+                  <Icon
+                    icon='tdesign:poweroff'
+                    width='18'
+                    height='18'
+                    className='text-black'
+                  />
+                  <HeaderAuthButton type='logout' />
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
+      </div>
     </nav>
   );
 };

--- a/src/components/main/main-Intor-section.tsx
+++ b/src/components/main/main-Intor-section.tsx
@@ -60,7 +60,7 @@ const MainIntorSection = () => {
         </div>
       </div>
       <button
-        className='absolute bottom-1 left-1/2 -translate-x-1/2 animate-bounce text-primary-40 md:bottom-7'
+        className='animate-bounce-y absolute bottom-1 left-1/2 flex -translate-x-1/2 items-center justify-center text-primary-40 md:bottom-7'
         aria-label='아래로 스크롤'
         onClick={() =>
           window.scrollBy({ top: window.innerHeight, behavior: 'smooth' })

--- a/src/components/main/main-footer.tsx
+++ b/src/components/main/main-footer.tsx
@@ -18,7 +18,7 @@ const MainFooter = () => {
   return (
     <footer className='w-full bg-black'>
       {/* 1) Developer/Designer 라인 (높이 128px) */}
-      <div className='flex flex-col items-center md:mx-[128px] md:h-[128px] md:flex-row md:justify-center md:gap-[296px]'>
+      <div className='mx-auto flex flex-col items-center justify-between px-16 md:h-[128px] md:flex-row'>
         {/* 왼쪽 로고 */}
         <Image
           src='/logo-white.png'

--- a/src/components/main/main-footer.tsx
+++ b/src/components/main/main-footer.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Icon } from '@iconify/react/dist/iconify.js';
 import Image from 'next/image';
 import React from 'react';

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -39,7 +39,7 @@ const sheetVariants = cva(
         top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
         bottom:
           'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
-        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        left: 'inset-y-0 left-0 h-full w-full max-w-[252px] border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
         right:
           'inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
       },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -107,10 +107,21 @@ const config: Config = {
           '0%': { transform: 'translateY(-100%)' },
           '100%': { transform: 'translateY(0)' },
         },
+        'bounce-y': {
+          '0%, 100%': {
+            transform: 'translateY(0)',
+            animationTimingFunction: 'cubic-bezier(0.8, 0, 1, 1)',
+          },
+          '50%': {
+            transform: 'translateY(-12px)',
+            animationTimingFunction: 'cubic-bezier(0, 0, 0.2, 1)',
+          },
+        },
       },
       animation: {
         moveLeft: 'moveLeft 20s linear infinite',
         moveUp: 'moveUp 60s linear infinite',
+        'bounce-y': 'bounce-y 1.5s infinite',
       },
     },
   },


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #369

<br>

## 📝 작업 내용

- 헤더 Ui 수정을 하고 반응형으로 바꿨습니다
- 만들기는 일단은 주석처리했습니다

<br>

## 🖼 스크린샷
<img width="812" alt="스크린샷 2025-04-30 오전 3 56 22" src="https://github.com/user-attachments/assets/ea7cdb38-7789-4256-a4e3-acaafbfcc0fc" />
<img width="812" alt="스크린샷 2025-04-30 오전 3 56 30" src="https://github.com/user-attachments/assets/1611881b-d4f1-4686-be46-822886df6c74" />

<img width="812" alt="스크린샷 2025-04-30 오전 3 56 54" src="https://github.com/user-attachments/assets/62f989ed-fc46-476a-a722-52d69de1feb5" />

이미지

<br>

## 💬 리뷰 요구사항

> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 모바일 환경에서 햄버거 아이콘을 통한 슬라이드 인 메뉴(시트 UI 패턴) 지원이 추가되어, 사용자 정보, 내비게이션 링크, 로그아웃 버튼 등이 포함된 모바일 메뉴를 제공합니다.
  - 버튼에 "mobile" 사이즈 옵션이 추가되었습니다.

- **스타일**
  - 모바일 시트 메뉴의 너비가 전체 폭에서 최대 252px로 조정되어 더욱 일관된 모바일 경험을 제공합니다.
  - 데스크탑 및 모바일 메뉴의 패딩, 간격, 로고 크기 등 일부 스타일이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->