### PR TITLE
[BUGFIX] #392 유입경로 차트 날짜 오류 픽스

### DIFF
--- a/src/apis/monthly-chart.api.ts
+++ b/src/apis/monthly-chart.api.ts
@@ -8,7 +8,7 @@ import { createClient } from '@/utils/supabase/client';
  * @returns 월별 날짜 배열, 조회수 및 저장수 카운트, 조회 기간 시작/종료일
  */
 export const getUserMonthlyLineData = async (userId: string) => {
-  const supabase = await createClient();
+  const supabase = createClient();
    // 이번 달의 시작(start), 종료(end) 날짜와 월 내 각 날짜 배열(monthDates) 계산
   const { start, end, monthDates } = getCurrentMonthRange();
 
@@ -105,7 +105,7 @@ export const getUserMonthlyLineData = async (userId: string) => {
  *          조회수 차이(viewsDifference), 저장수 차이(savesDifference)
  */
 export const getUserMonthlyStats = async (userId: string) => {
-  const supabase = await createClient();
+  const supabase = createClient();
   const { start, end, beforeStart, beforeEnd } = getCurrentMonthRange();
 
   // 사용자 명함 가져오기
@@ -193,7 +193,7 @@ export const getUserMonthlyStats = async (userId: string) => {
  * @returns 명함 ID, 제목, 이번 달 조회수, 이전 달 조회수, 조회수 차이
  */
 export const getMostViewedCard = async (userId: string) => {
-  const supabase = await createClient();
+  const supabase = createClient();
   const { start, end, beforeStart, beforeEnd } = getCurrentMonthRange();
 
   // 사용자 소유 명함id, title 가져오기

--- a/src/apis/weekly-source-count.api.ts
+++ b/src/apis/weekly-source-count.api.ts
@@ -30,7 +30,7 @@ interface WeeklySourceCount {
 export const getWeeklySourceCounts = async (
   cardId: string
 ): Promise<WeeklySourceCount[]> => {
-  const supabase = await createClient();
+  const supabase = createClient();
 
   // 로컬 기준 현재 연도/월 추출
   const now = new Date();

--- a/src/apis/weekly-source-count.api.ts
+++ b/src/apis/weekly-source-count.api.ts
@@ -32,10 +32,10 @@ export const getWeeklySourceCounts = async (
 ): Promise<WeeklySourceCount[]> => {
   const supabase = await createClient();
 
-  // UTC 기준 현재 연도/월 추출
+  // 로컬 기준 현재 연도/월 추출
   const now = new Date();
-  const year = now.getUTCFullYear();
-  const month = now.getUTCMonth(); // 0=1월, 11=12월
+  const year = now.getFullYear();
+  const month = now.getMonth(); // 0=1월, 11=12월
 
   // 월별 주 범위 계산 (일요일~토요일)
   const weeks = getWeeksInMonth(year, month);
@@ -72,17 +72,17 @@ export const getWeeklySourceCounts = async (
       rows.filter((row) => row[DB_COLUMNS.CARD_VIEWS.SOURCE] === source).length;
 
     // 차트 레이블 포맷터: "D일~D일"
-    const labelFormatter= (iso: string) => {
+    const labelFormatter = (iso: string) => {
       const d = new Date(iso);
-      const dd = String(d.getUTCDate());
+      const dd = String(d.getDate());
       return dd;
     };
 
-    const startDate =labelFormatter(start);
-    const endDate =labelFormatter(end);
+    const startDate = labelFormatter(start);
+    const endDate = labelFormatter(end);
 
     // 월 정보 추출
-    const monthStr = String(new Date(start).getUTCMonth() + 1);
+    const monthStr = String(new Date(start).getMonth() + 1);
 
     return {
       weekLabel: `${startDate}일~${endDate}일`,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #392 

<br>

## 📝 작업 내용

- DB의 날짜와 코드의 날짜 계산 방식 차이 확인 후 모두 로컬데이터 계산방식으로 수정 하여 월月이 바뀌는 시점 통일
- 필요없는 await 삭체

<br>

## 🖼 스크린샷
`as-is`
<img width="461" alt="스크린샷 2025-05-01 오전 1 11 31" src="https://github.com/user-attachments/assets/5d82e3f4-8657-4af7-a4fe-2957535b5f40" />

`to-be`
<img width="498" alt="스크린샷 2025-05-01 오전 1 16 17" src="https://github.com/user-attachments/assets/8de2c930-cce5-421e-ab71-e9bd69896849" />

<br>

## 💬 리뷰 요구사항

> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 월별 및 주별 차트 데이터의 날짜 계산이 UTC 기준에서 로컬 시간 기준으로 변경되어, 사용자의 로컬 타임존에 맞는 데이터가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->