### PR TITLE
[FEAT]/#401 에디터 템플릿 수정

### DIFF
--- a/src/components/editor/elements/templates/templates-sidebar.tsx
+++ b/src/components/editor/elements/templates/templates-sidebar.tsx
@@ -50,11 +50,7 @@ const TemplateSidebar = () => {
       {templates?.data.slice().map((template, idx) => (
         <div
           key={template.id}
-          onClick={
-            idx === 0
-              ? () => handleApplyTemplate(template)
-              : toastComingSoonAlert
-          }
+          onClick={() => handleApplyTemplate(template)}
           className='cursor-pointer space-y-[14px] border'
         >
           <img

--- a/src/components/editor/elements/templates/templates-sidebar.tsx
+++ b/src/components/editor/elements/templates/templates-sidebar.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useTemplateList } from '@/hooks/queries/use-template-list';
+import { toastSuccess } from '@/lib/toast-util';
+import { sideBarStore } from '@/store/editor.sidebar.store';
 import { useEditorStore } from '@/store/editor.store';
 import { CardContent } from '@/types/editor.type';
 import { Templates } from '@/types/supabase.type';
-import { toastComingSoonAlert } from '@/utils/common/sweet-coming-soon-alert';
+import sweetAlertUtil from '@/utils/common/sweet-alert-util';
 
 const TemplateSidebar = () => {
   const { data: templates, isPending, isError } = useTemplateList();
@@ -20,25 +22,42 @@ const TemplateSidebar = () => {
   const setBackgroundColorBack = useEditorStore(
     (state) => state.setBackgroundColorBack
   );
+  const { isHorizontal, setIsHorizontal, setZoom } = sideBarStore.getState();
+
+  //필터링
+  const filteredTemplates = templates?.data.filter(
+    (tplist) => tplist.isHorizontal === isHorizontal
+  );
 
   //템플릿 적용 핸들러
-  const handleApplyTemplate = (template: Templates) => {
-    if (!template.content) return;
-    const content = template.content as CardContent;
-    setTemplate(template);
+  const handleApplyTemplate = async (template: Templates) => {
+    sweetAlertUtil.confirm({
+      title: '템플릿 선택',
+      text: '템플릿을 변경하시면 내용이 초기화됩니다.',
+      icon: 'warning',
+      onConfirm: () => {
+        if (!template.content) return;
 
-    if (content.canvasElements) {
-      setCanvasElements(content.canvasElements);
-    }
-    if (content.backgroundColor) {
-      setBackgroundColor(content.backgroundColor);
-    }
-    if (content.canvasBackElements) {
-      setCanvasBackElements(content.canvasBackElements);
-    }
-    if (content.backgroundColorBack) {
-      setBackgroundColorBack(content.backgroundColorBack);
-    }
+        const content = template.content as CardContent;
+        setTemplate(template);
+
+        if (content.canvasElements) {
+          setCanvasElements(content.canvasElements);
+        }
+        if (content.backgroundColor) {
+          setBackgroundColor(content.backgroundColor);
+        }
+        if (content.canvasBackElements) {
+          setCanvasBackElements(content.canvasBackElements);
+        }
+        if (content.backgroundColorBack) {
+          setBackgroundColorBack(content.backgroundColorBack);
+        }
+      },
+      onCancel: () => {
+        toastSuccess('취소되었습니다');
+      },
+    });
   };
 
   if (isPending) return <p>불러오는 중...</p>;
@@ -47,7 +66,7 @@ const TemplateSidebar = () => {
   return (
     <div className='mt-[14px] h-full w-full space-y-4 overflow-auto px-[18px]'>
       <p className='text-caption-medium'>템플릿</p>
-      {templates?.data.slice().map((template, idx) => (
+      {filteredTemplates?.map((template) => (
         <div
           key={template.id}
           onClick={() => handleApplyTemplate(template)}

--- a/src/utils/editor/warn-sweet-alert.ts
+++ b/src/utils/editor/warn-sweet-alert.ts
@@ -9,7 +9,8 @@ export const handleSwitchCard = (horizontal: boolean) => {
   const { canvasElements, canvasBackElements, reset, template } =
     useEditorStore.getState();
 
-  const { isHorizontal, setIsHorizontal, setZoom } = sideBarStore.getState();
+  const { isHorizontal, setIsHorizontal, setZoom, setSideBarStatus } =
+    sideBarStore.getState();
 
   const isContent = canvasElements.length > 0 || canvasBackElements.length > 0;
 
@@ -39,6 +40,7 @@ export const handleSwitchCard = (horizontal: boolean) => {
       if (result.isConfirmed) {
         sweetAlertUtil.success('변경되었습니다!');
         reset();
+        setSideBarStatus(false);
         flipSetting();
       }
     });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #401 

<br>

## 📝 작업 내용

- 템플릿 다음에 만나요 삭제
- 클릭시 실제 템플릿 적용
- 가로 모드면 가로 템플릿만 세로모드면 세로템플릿만
- 가로 세로 변경시 사이드바 닫기 
-

<br>


https://github.com/user-attachments/assets/7146d90b-8ddc-4409-8f24-83f0fe5fb558



이미지

<br>

## 💬 리뷰 요구사항

> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 템플릿 사이드바에서 현재 카드 방향에 맞는 템플릿만 표시되며, 모든 템플릿을 클릭하여 적용할 수 있습니다.
  - 템플릿 적용 시 확인 다이얼로그가 나타나며, 취소 시 취소 알림이 표시됩니다.

- **버그 수정**
  - 카드 방향 전환 시 사이드바가 자동으로 닫히도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->