### PR TITLE
[STYLE]#409 내 명함 상세 페이지 주간 차트 라벨 색상 및 세로 명함 영역 플립 아이콘 위치 재설정

### DIFF
--- a/src/components/card-detail/weekly-chart.tsx
+++ b/src/components/card-detail/weekly-chart.tsx
@@ -84,19 +84,23 @@ const WeeklyChart = ({ card_id }: WeeklyChartProps) => {
         <div className='col-span-1 mb-[2px] mt-[19px] flex items-start justify-center text-caption-regular text-gray-50 md:mb-6 md:mt-0 md:flex-col'>
           <div className='mx-auto my-0 flex w-full flex-row text-label1-medium text-black md:w-auto md:flex-col'>
             <div className='flex flex-1 flex-row items-center justify-center gap-2 md:flex-col md:gap-0'>
-              <p className='text-extra-medium text-gray-70 md:text-label2-medium'>
+              <p
+                className={`text-extra-medium md:text-label2-medium ${calculateTotalWithUnit(weekViewCnt) === '0회' ? 'text-gray-70' : 'text-primary-40'}`}
+              >
                 주간 조회 수
               </p>
-              <p className='text-label2-medium md:mb-1 md:text-body-medium'>
+              <p className='text-label2-medium text-gray-70 md:mb-1 md:text-body-medium'>
                 {calculateTotalWithUnit(weekViewCnt)}
               </p>
             </div>
             <div className='mx-2 h-[26px] w-[1px] bg-bg md:hidden' />
             <div className='flex flex-1 flex-row items-center justify-center gap-2 md:flex-col md:gap-0'>
-              <p className='text-extra-medium text-gray-70 md:text-label2-medium'>
+              <p
+                className={`text-extra-medium md:text-label2-medium ${calculateTotalWithUnit(weekSaveCnt) === '0회' ? 'text-gray-70' : 'text-[#E66B00]'}`}
+              >
                 주간 저장 수
               </p>
-              <p className='text-label2-medium md:text-body-medium'>
+              <p className='text-label2-medium text-gray-70 md:text-body-medium'>
                 {calculateTotalWithUnit(weekSaveCnt)}
               </p>
             </div>

--- a/src/components/card/flip-card.tsx
+++ b/src/components/card/flip-card.tsx
@@ -227,7 +227,7 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
       ? 'bottom-[-20px] md:bottom-[-20px]'
       : isDetail
         ? 'bottom-[-20px]'
-        : 'bottom-[-54px]';
+        : 'bottom-[3px] md:bottom-[-54px]';
 
   return (
     <div

--- a/src/components/card/flip-card.tsx
+++ b/src/components/card/flip-card.tsx
@@ -101,7 +101,8 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
   // 스타일 상수
   const CARD_DEFAULT_STYLE =
     'absolute flex h-full w-full items-center justify-center shadow-[20px_60px_20px_0px_rgba(0,0,0,0.00),12px_40px_15px_0px_rgba(0,0,0,0.01),7px_20px_12px_0px_rgba(0,0,0,0.05),3px_10px_10px_0px_rgba(0,0,0,0.09),1px_3px_5px_0px_rgba(0,0,0,0.10)] backface-hidden';
-  const CARD_DEFAULT_BUTTON_STYLE = 'z-10 h-[40px] w-[40px] cursor-pointer';
+  const CARD_DEFAULT_BUTTON_STYLE =
+    'z-10 h-[40px] w-[40px] cursor-pointer absolute';
   const startRef = useRef(new Date());
 
   // 추적 세션 초기화
@@ -223,8 +224,10 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
   // 버튼 위치 계산
   const buttonPosition =
     isDetail && data.isHorizontal
-      ? 'absolute bottom-[-20px] md:bottom-[-20px]'
-      : 'absolute bottom-[-54px]';
+      ? 'bottom-[-20px] md:bottom-[-20px]'
+      : isDetail
+        ? 'bottom-[-20px]'
+        : 'bottom-[-54px]';
 
   return (
     <div
@@ -238,7 +241,7 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
           'relative perspective-1000',
           width,
           height,
-          !data.isHorizontal && 'py-[20px]'
+          !data.isHorizontal && !isDetail && 'py-[20px]'
         )}
       >
         <div


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #409

<br>

## 📝 작업 내용

- 내 명함 상세 페이지 주간 차트 데이터가 있을 경우 색상 표시
- 가로 명함 디자인 시안 추가 요청 시안 반영시 세로 명함 플립 아이콘이 겹치는 문제 해결

<br>

## 🖼 스크린샷


<br>

## 💬 리뷰 요구사항

> 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
    - "주간 조회 수"와 "주간 저장 수" 라벨의 색상이 총 카운트에 따라 동적으로 변경됩니다. 0회일 경우 회색, 그 외에는 각각 주요 색상과 오렌지 색상으로 표시됩니다.
    - 카드 버튼의 위치 및 카드 컨테이너의 패딩 적용 방식이 더 세밀하게 조정되어, 상세 보기 및 방향에 따라 시각적 정렬이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->