### PR TITLE
[REFACTOR]카드 삭제 후 정렬 쿼리 무효화 로직 추가 #411

### DIFF
--- a/src/hooks/mutations/use-mycard-delete.ts
+++ b/src/hooks/mutations/use-mycard-delete.ts
@@ -46,6 +46,9 @@ export const useMyCardDelete = ({
           queryClient.invalidateQueries({
             queryKey: [QUERY_KEY.CARD_INTERACTION, slug],
           }),
+          queryClient.invalidateQueries({
+            queryKey: [QUERY_KEY.SORT_CARD, userId],
+          }),
         ]);
 
         // 카드 목록 새로고침


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #411

<br>

## 📝 작업 내용

- 카드 삭제 쿼리 키 추가

<br>

## 🖼 스크린샷

이미지

<br>

## 💬 리뷰 요구사항

> 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 카드 삭제 후 사용자별 정렬된 카드 목록이 올바르게 새로고침되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->