### PR TITLE
[BUGFIX] 방문자 클릭 분석 통계 로직 수정

### DIFF
--- a/src/apis/interaction.ts
+++ b/src/apis/interaction.ts
@@ -74,7 +74,7 @@ export const logInteraction = async ({
   }
 
   // 이미 존재하는 세션인 경우 업데이트
-  if (existingData) {
+  if (elementName === null && existingData) {
     const { error: updateError } = await supabase
       .from(TABLES.CARD_VIEWS)
       .update({
@@ -91,7 +91,6 @@ export const logInteraction = async ({
     }
     return existingData;
   }
-
   // 새로운 세션인 경우에만 insert
   const { data, error } = await supabase.from(TABLES.CARD_VIEWS).insert({
     card_id: cardId,

--- a/src/app/[...slug]/page.client.tsx
+++ b/src/app/[...slug]/page.client.tsx
@@ -2,7 +2,6 @@
 
 import FlipCard, { FlipCardRef } from '@/components/card/flip-card';
 import LeftArrow from '@/components/icons/left-arrow';
-import { ROUTES } from '@/constants/path.constant';
 import { useLogInteractionMutation } from '@/hooks/mutations/use-init-session';
 import { useIpAddressQuery } from '@/hooks/queries/use-ip-address';
 import { useInteractionTracker } from '@/hooks/use-interaction-tracker';
@@ -11,10 +10,8 @@ import { authStore } from '@/store/auth.store';
 import { Cards, CardViews } from '@/types/supabase.type';
 import { getEffectiveSessionId } from '@/utils/interaction/session-util';
 import { toastComingSoonAlert } from '@/utils/common/sweet-coming-soon-alert';
-
 import clsx from 'clsx';
-import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
 interface SlugClientPageParams {
@@ -49,6 +46,7 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
 
   const { handleSaveImg, updateActivity, handleSaveVCard } =
     useInteractionTracker({
+      cardId: id,
       isDetail: false,
       slug,
       source,
@@ -65,7 +63,12 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
   );
 
   const [hasInitialViewId, setHasInitialViewId] = useState<number | null>(null);
+
+  const router = useRouter();
   const isMyCard = initialData.user_id === userId;
+  const handleGoBack = () => {
+    router.back();
+  };
 
   // 무한 루프 방지를 위한 처리 상태 추적 ref
   const initialViewProcessedRef = useRef(false);
@@ -157,13 +160,13 @@ const SlugClientPage = ({ initialData }: SlugClientPageParams) => {
       <div className='absolute left-0 top-0 z-50 flex h-[52px] w-full items-center justify-center border-b border-gray-10 bg-white shadow-sm md:h-[80px]'>
         <div className='relative flex h-full w-full items-center justify-center px-[20px] py-[14px] text-label1-semi md:justify-start md:px-[22px] md:py-5 md:text-title-bold'>
           {isMyCard && (
-            <Link
-              href={`${ROUTES.MYCARD}/${initialData.id}`}
+            <button
+              onClick={handleGoBack}
               className='absolute left-[20px] cursor-pointer md:static md:mr-[14px]'
               aria-label='내 명함상세로 이동하기'
             >
               <LeftArrow size={isMobile ? 24 : 32} />
-            </Link>
+            </button>
           )}
           <h2 className='max-w-[80%] truncate md:max-w-full'>{pageTitle}</h2>
         </div>

--- a/src/components/card/flip-card.tsx
+++ b/src/components/card/flip-card.tsx
@@ -133,18 +133,19 @@ const FlipCard = forwardRef<FlipCardRef, FlipCardParam>(({ isDetail }, ref) => {
     return null;
   })();
 
+  // 카드 콘텐츠 가져오기
+  const { data, isPending, error } = useCardContent(
+    isDetail ? slug || '' : pathArray
+  );
+
   // 인터랙션 트래커 설정
   const { handleClick } = useInteractionTracker({
+    cardId: data?.id || '',
     isDetail: !!isDetail,
     slug: isDetail ? slug || '' : pathArray,
     source: source ?? 'direct',
     startedAt: startedAt ?? new Date(),
   });
-
-  // 카드 콘텐츠 가져오기
-  const { data, isPending, error } = useCardContent(
-    isDetail ? slug || '' : pathArray
-  );
 
   // 로딩 중일 때 스켈레톤 UI
   if (isPending) {

--- a/src/hooks/mutations/use-init-session.ts
+++ b/src/hooks/mutations/use-init-session.ts
@@ -26,7 +26,7 @@ export const useInitSessionMutation = (startedAt: Date) => {
     mutationFn: async (params: {
       cardId: string;
       viewerIp: string;
-      source: 'direct' | 'qr' | 'link' | 'tag' | null;
+      source: 'direct' | 'qr' | 'link' | 'tag' | null | undefined;
     }): Promise<SessionData> => {
       if (!startedAt) throw new Error('시작 시간이 필요합니다.');
 

--- a/src/hooks/use-interaction-tracker.ts
+++ b/src/hooks/use-interaction-tracker.ts
@@ -11,6 +11,7 @@ import { authStore } from '@/store/auth.store';
 import { useImageDownloader } from '@/hooks/use-image-downloader';
 
 interface InteractionProps {
+  cardId: string;
   isDetail: boolean;
   slug: string;
   source: 'direct' | 'qr' | 'link' | 'tag' | null | undefined;
@@ -29,16 +30,12 @@ const MIN_UPDATE_INTERVAL = 5000; // 5초
  * 인터랙션 추적 훅
  */
 export const useInteractionTracker = ({
+  cardId,
   isDetail,
   slug,
   source: sourceParam,
   startedAt,
-}: {
-  isDetail: boolean;
-  slug: string;
-  source: 'direct' | 'qr' | 'link' | 'tag';
-  startedAt: Date;
-}) => {
+}: InteractionProps) => {
   const searchParams = useSearchParams();
   const sourceFromParams = searchParams.get('source') as
     | 'direct'
@@ -62,7 +59,7 @@ export const useInteractionTracker = ({
     sessionStartTimeRef.current
   );
   const logInteractionMutation = useLogInteractionMutation(
-    slug,
+    cardId,
     ip || '',
     sourceFromParams || sourceParam,
     startedAt
@@ -102,10 +99,9 @@ export const useInteractionTracker = ({
 
     const initializeSession = async () => {
       if (sessionInitializedRef.current) return;
-
       try {
         const result = await initSessionMutation.mutateAsync({
-          cardId: slug,
+          cardId: cardId,
           viewerIp: ip,
           source: sourceFromParams || sourceParam,
         });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #419

<br>

## 📝 작업 내용

- 명함 id 인터렉션 추적 훅에 추가
- 세션 초기화 로직 개선

<br>

## 🖼 스크린샷



<br>

## 💬 리뷰 요구사항

> 없습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 여러 화면에서 사용자 상호작용 추적 시 카드 ID(cardId) 기반 추적이 적용되었습니다.

- **버그 수정**
	- 세션 업데이트 조건이 개선되어, 특정 상황에서 불필요한 세션 갱신이 방지됩니다.

- **리팩터**
	- 뒤로 가기(Back) 버튼이 내비게이션 링크 대신 브라우저의 뒤로 가기 동작을 사용하도록 변경되었습니다.
	- 카드 플립 컴포넌트에서 내부 훅 호출 순서가 조정되었습니다.

- **타입 개선**
	- 세션 초기화 시 source 파라미터가 undefined도 허용하도록 타입이 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->