### PR TITLE
[FEAT] 벨로그 도넛 차트 아이템 추가

### DIFF
--- a/src/apis/user-click-donut-chart.api.ts
+++ b/src/apis/user-click-donut-chart.api.ts
@@ -19,6 +19,7 @@ export const getUserClickDonutChartData = async (
     instagram: '인스타',
     linkedin: '링크드인',
     youtube: '유튜브',
+    velog: '벨로그',
   };
 
   // 원하는 표시 순서
@@ -31,6 +32,7 @@ export const getUserClickDonutChartData = async (
     'instagram',
     'linkedin',
     'youtube',
+    'velog',
   ];
 
   const supabase = createClient();

--- a/src/components/chart/donut-chart.tsx
+++ b/src/components/chart/donut-chart.tsx
@@ -16,6 +16,7 @@ const chart2Colors = {
   insta: '#6792CF', // chart2-insta
   linkedin: '#8690EE', // chart2-linkedin
   youtube: '#EE86E0', // char2-youtube
+  velog: '#7F2A2A', // chart2-velog
 };
 
 // gray 색상 참조
@@ -87,6 +88,7 @@ const DonutChart = () => {
           chart2Colors.insta, // #6792CF
           chart2Colors.linkedin, // #8690EE
           chart2Colors.youtube, // #EE86E0
+          chart2Colors.velog, // #7F2A2A
         ],
       },
     ],

--- a/src/components/chart/donut-chart.tsx
+++ b/src/components/chart/donut-chart.tsx
@@ -16,7 +16,7 @@ const chart2Colors = {
   insta: '#6792CF', // chart2-insta
   linkedin: '#8690EE', // chart2-linkedin
   youtube: '#EE86E0', // char2-youtube
-  velog: '#7F2A2A', // chart2-velog
+  velog: '#E85A8A', // chart2-velog
 };
 
 // gray 색상 참조
@@ -88,7 +88,7 @@ const DonutChart = () => {
           chart2Colors.insta, // #6792CF
           chart2Colors.linkedin, // #8690EE
           chart2Colors.youtube, // #EE86E0
-          chart2Colors.velog, // #7F2A2A
+          chart2Colors.velog, // #E85A8A
         ],
       },
     ],

--- a/src/config/tailwind.colors.ts
+++ b/src/config/tailwind.colors.ts
@@ -46,7 +46,7 @@ const uunoColors = {
     notion: '#64B0F9', // 원형 그래프/노션
     vcard: '#FF143F', // 원형 그래프/연락처 저장
     youtube: '#EE86E0', // 원형 그래프/유튜브
-    velog: '#7F2A2A', // 원형 그래프/벨로그
+    velog: '#E85A8A', // 원형 그래프/벨로그
   },
 };
 

--- a/src/config/tailwind.colors.ts
+++ b/src/config/tailwind.colors.ts
@@ -46,6 +46,7 @@ const uunoColors = {
     notion: '#64B0F9', // 원형 그래프/노션
     vcard: '#FF143F', // 원형 그래프/연락처 저장
     youtube: '#EE86E0', // 원형 그래프/유튜브
+    velog: '#7F2A2A', // 원형 그래프/벨로그
   },
 };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #425

<br>

## 📝 작업 내용

- 사용자 방문자 클릭 분석 velog 항목 추가
- velog 항목 색상 '#E85A8A' 추가 (색상은 기존 색상 순서대로 배치)

<br>

## 🖼 스크린샷

<img width="1414" alt="스크린샷 2025-05-31 오후 6 46 32" src="https://github.com/user-attachments/assets/cd23f867-8258-4568-969f-50064f0c2b2f" />


<br>

## 💬 리뷰 요구사항

> velog에 '#E85A8A' 색상을 써도 괜찮을까요?
차트 항목마다 개별 색상이 지정되는 건 아니고,
색상은 코드에 작성된 순서대로 차례차례 적용돼요!
